### PR TITLE
Add MediaButtonReceiver

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -211,6 +211,13 @@
                 <action android:name="com.suvojeet.suvmusic.pip.PREVIOUS" />
             </intent-filter>
         </receiver>
+        <receiver
+            android:name="androidx.media3.session.MediaButtonReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
         
     </application>
 


### PR DESCRIPTION
It allows apps like Tasker to send PLAY/PAUSE intents to start your music automatically (e.g., "When Bluetooth connects").