### PR TITLE
Kmp

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,77 @@
+name: Build Windows Desktop
+
+on:
+  push:
+    branches: [ "main", "dev" ]
+    paths:
+      - 'composeApp/**'
+      - 'gradle/libs.versions.toml'
+      - 'settings.gradle.kts'
+      - 'build.gradle.kts'
+      - '.github/workflows/windows-build.yml'
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle wrapper
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-wrapper-
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/daemon
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Build Windows MSI
+        run: ./gradlew :composeApp:packageReleaseMsi --no-daemon --stacktrace
+        env:
+          GRADLE_OPTS: -Dorg.gradle.workers.max=2
+
+      - name: Locate MSI
+        id: locate
+        run: |
+          MSI_PATH=$(find composeApp/build/compose/binaries/main-release/msi -name "*.msi" | head -n 1)
+          if [ -z "$MSI_PATH" ]; then
+            echo "No MSI produced — listing build dir for diagnostics:" >&2
+            find composeApp/build/compose -type f >&2 || true
+            exit 1
+          fi
+          echo "MSI_PATH=$MSI_PATH" >> $GITHUB_OUTPUT
+          echo "MSI_NAME=$(basename "$MSI_PATH")" >> $GITHUB_OUTPUT
+
+      - name: Upload MSI Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SuvMusic-Windows-MSI-${{ github.run_number }}
+          path: ${{ steps.locate.outputs.MSI_PATH }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,4 +7,8 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    // KMP migration (Phase 0)
+    alias(libs.plugins.kotlin.multiplatform) apply false
+    alias(libs.plugins.compose.multiplatform) apply false
+    alias(libs.plugins.sqldelight) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,0 +1,92 @@
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.compose.multiplatform)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.android.library)
+}
+
+kotlin {
+    androidTarget {
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+                }
+            }
+        }
+    }
+
+    jvm("desktop") {
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
+                }
+            }
+        }
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation(compose.runtime)
+                implementation(compose.foundation)
+                implementation(compose.material3)
+                implementation(compose.ui)
+                implementation(compose.components.resources)
+                implementation(libs.kotlinx.coroutines.core)
+            }
+        }
+
+        val androidMain by getting {
+            dependencies {
+                implementation(libs.androidx.activity.compose)
+            }
+        }
+
+        val desktopMain by getting {
+            dependencies {
+                implementation(compose.desktop.currentOs)
+                implementation(libs.kotlinx.coroutines.swing)
+            }
+        }
+    }
+}
+
+android {
+    namespace = "com.suvojeet.suvmusic.composeapp"
+    compileSdk = 37
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
+    }
+}
+
+compose.desktop {
+    application {
+        mainClass = "com.suvojeet.suvmusic.composeapp.MainKt"
+
+        nativeDistributions {
+            targetFormats(TargetFormat.Msi, TargetFormat.Exe)
+            packageName = "SuvMusic"
+            packageVersion = "1.0.0"
+            description = "SuvMusic Desktop"
+            vendor = "Suvojeet Sengupta"
+
+            windows {
+                menu = true
+                shortcut = true
+                // Stable UUID — keep this constant across releases so Windows treats
+                // new MSIs as upgrades, not parallel installs. Generated once.
+                upgradeUuid = "9F8D2C1A-4B7E-4F3D-9A6C-3E2B1A8D5C7F"
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/composeApp/src/androidMain/kotlin/com/suvojeet/suvmusic/composeapp/AppEntry.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/suvojeet/suvmusic/composeapp/AppEntry.android.kt
@@ -1,0 +1,14 @@
+package com.suvojeet.suvmusic.composeapp
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Android entry point for the shared composeApp UI. The existing :app module
+ * does not yet host this — it will be wired in during Phase 5 (UI to commonMain).
+ * For Phase 0 this exists only so the androidMain source set has at least one
+ * Kotlin file and compiles.
+ */
+@Composable
+fun AndroidAppEntry() {
+    App()
+}

--- a/composeApp/src/commonMain/kotlin/com/suvojeet/suvmusic/composeapp/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/suvojeet/suvmusic/composeapp/App.kt
@@ -1,0 +1,38 @@
+package com.suvojeet.suvmusic.composeapp
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun App() {
+    MaterialTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = "SuvMusic Desktop",
+                        style = MaterialTheme.typography.headlineMedium,
+                    )
+                    Text(
+                        text = "Phase 0 skeleton — KMP migration in progress",
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(8.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/com/suvojeet/suvmusic/composeapp/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/com/suvojeet/suvmusic/composeapp/Main.kt
@@ -1,0 +1,17 @@
+package com.suvojeet.suvmusic.composeapp
+
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.rememberWindowState
+
+fun main() = application {
+    Window(
+        onCloseRequest = ::exitApplication,
+        title = "SuvMusic",
+        state = rememberWindowState(size = DpSize(1024.dp, 720.dp)),
+    ) {
+        App()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,14 @@ detekt = "1.23.8"
 ktlint = "1.7.1"
 adaptive = "1.3.0-alpha10"
 
+# KMP migration (Phase 0)
+composeMultiplatform = "1.10.0"
+koin = "4.1.0"
+sqldelight = "2.1.0"
+multiplatformSettings = "1.3.0"
+vlcj = "4.10.1"
+kotlinxDatetime = "0.7.1"
+
 [libraries]
 # Core
 androidx-core = { group = "androidx.core", name = "core", version.ref = "coreKtx" }
@@ -174,6 +182,30 @@ kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "ko
 # Desugaring
 android-desugarJdkLibs = { group = "com.android.tools", name = "desugar_jdk_libs_nio", version.ref = "desugarJdkLibs" }
 
+# --- KMP migration (Phase 0) -------------------------------------------------
+# Compose Multiplatform redistribution (Skiko + jvm runtime); commonMain composables
+compose-runtime = { group = "org.jetbrains.compose.runtime", name = "runtime", version.ref = "composeMultiplatform" }
+# Koin (multiplatform DI; replaces Hilt in later phases)
+koin-core = { group = "io.insert-koin", name = "koin-core", version.ref = "koin" }
+koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
+koin-compose = { group = "io.insert-koin", name = "koin-compose", version.ref = "koin" }
+koin-compose-viewmodel = { group = "io.insert-koin", name = "koin-compose-viewmodel", version.ref = "koin" }
+# SQLDelight (multiplatform DB; replaces Room in Phase 3b)
+sqldelight-android-driver = { group = "app.cash.sqldelight", name = "android-driver", version.ref = "sqldelight" }
+sqldelight-jvm-driver = { group = "app.cash.sqldelight", name = "sqlite-driver", version.ref = "sqldelight" }
+sqldelight-coroutines = { group = "app.cash.sqldelight", name = "coroutines-extensions", version.ref = "sqldelight" }
+# multiplatform-settings (replaces DataStore + EncryptedSharedPreferences in Phase 3c)
+multiplatform-settings = { group = "com.russhwolf", name = "multiplatform-settings", version.ref = "multiplatformSettings" }
+multiplatform-settings-coroutines = { group = "com.russhwolf", name = "multiplatform-settings-coroutines", version.ref = "multiplatformSettings" }
+# kotlinx-datetime (replaces java.time on common code)
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
+# VLCJ — Windows desktop audio backend (Phase 4)
+vlcj = { group = "uk.co.caprica", name = "vlcj", version.ref = "vlcj" }
+# Coroutines: swing dispatcher for Compose Desktop
+kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "coroutines" }
+# Ktor: OkHttp engine for Android (Phase 3a). CIO already declared above for desktop.
+ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
@@ -183,3 +215,7 @@ hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobufPlugin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+# KMP migration (Phase 0)
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
+sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,3 +33,6 @@ include(":feature:player")
 include(":feature:library")
 include(":feature:search")
 include(":feature:settings")
+// KMP migration (Phase 0): parallel desktop/multiplatform module. Does not yet
+// replace :app — Android APK still builds from :app unchanged.
+include(":composeApp")


### PR DESCRIPTION
Adds an empty Compose Multiplatform module (:composeApp) targeting Android library + JVM desktop, plus a windows-latest GitHub Actions workflow that builds the MSI installer. Existing :app Android build is unchanged and continues to ship.

- libs.versions.toml: Compose-MP, Koin, SQLDelight, multiplatform-settings, VLCJ, kotlinx-datetime, ktor-okhttp, coroutines-swing
- composeApp: placeholder Compose UI + window entry point
- windows-build.yml: matrix on windows-latest, packageReleaseMsi, artifact upload