### PR TITLE
fix(launcher-icon): add 16.6% safe-zone inset to Pulse/Resonance/Aeth…

### DIFF
--- a/app/src/main/res/drawable/ic_launcher_foreground_aether.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground_aether.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<bitmap xmlns:android="http://schemas.android.com/apk/res/android"
-    android:src="@drawable/logo_aether"
-    android:gravity="fill" />
+<!--
+  Aether launcher foreground. 16.6% inset keeps the orbital rings + note
+  inside the 66dp adaptive-icon safe zone — the outer ring otherwise gets
+  shaved off on circular launcher masks. `gravity="fill"` scales the 512px
+  bitmap into the inset bounds (intrinsic-sized "center" would crop it).
+-->
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:inset="16.6%">
+    <bitmap
+        android:src="@drawable/logo_aether"
+        android:gravity="fill" />
+</inset>

--- a/app/src/main/res/drawable/ic_launcher_foreground_pulse.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground_pulse.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Pulse launcher foreground. The variant PNG fills the full 108dp adaptive-
-  icon canvas (no inset). The launcher's circular / squircle / etc. mask
-  crops the outer ~7-15% of the canvas — but the S monogram and sine wave
-  sit within the central 67% of the source viewport, so the brand mark is
-  always intact regardless of mask shape. The PNG's own near-black radial
-  gradient handles the corners that the mask hides; the separate background
-  drawable is only there to satisfy adaptive-icon requirements.
+  Pulse launcher foreground. Wrapped in a 16.6% inset so the brand mark sits
+  inside the 66dp safe zone of the 108dp adaptive-icon canvas — without it,
+  Pixel's circular mask clips the S top-and-bottom (the source PNG has its
+  S near the canvas edges, not centered with breathing room).
 
-  Earlier this file used `<inset android:inset="20%">` wrapping a `<bitmap
-  android:gravity="center">` — that combination centred the 512px bitmap at
-  intrinsic size inside ~260px inset bounds, so only the central horizontal
-  strip rendered. Switching to `gravity="fill"` scales the bitmap to fit.
+  `gravity="fill"` is required: with `gravity="center"` the 512px bitmap
+  renders at intrinsic size inside the inset bounds and only the central
+  strip is visible.
 -->
-<bitmap xmlns:android="http://schemas.android.com/apk/res/android"
-    android:src="@drawable/logo_pulse"
-    android:gravity="fill" />
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:inset="16.6%">
+    <bitmap
+        android:src="@drawable/logo_pulse"
+        android:gravity="fill" />
+</inset>

--- a/app/src/main/res/drawable/ic_launcher_foreground_resonance.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground_resonance.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<bitmap xmlns:android="http://schemas.android.com/apk/res/android"
-    android:src="@drawable/logo_resonance"
-    android:gravity="fill" />
+<!--
+  Resonance launcher foreground. 16.6% inset keeps the vinyl + EQ mark inside
+  the 66dp adaptive-icon safe zone so circular launcher masks don't clip the
+  outer rim of the disc. `gravity="fill"` scales the 512px bitmap into the
+  inset bounds (intrinsic-sized "center" gravity would crop it).
+-->
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:inset="16.6%">
+    <bitmap
+        android:src="@drawable/logo_resonance"
+        android:gravity="fill" />
+</inset>


### PR DESCRIPTION
…er foregrounds

The hero PNGs filled the full 108dp adaptive-icon canvas with no inset, so Pixel's circular launcher mask clipped the S monogram (Pulse) and the outer ring (Aether) at top/bottom. Wrap each foreground bitmap in a 16.6% inset (the canonical 18/108 safe-zone value) so the brand mark sits inside the 66dp guaranteed-visible region on every mask shape.

gravity="fill" is preserved — earlier history removed the inset because it had been paired with gravity="center", which renders the 512px PNG at intrinsic size inside the inset bounds and crops to the central strip. With fill, the bitmap scales to the inset and the icon renders correctly.