### PR TITLE
redesign(home): phase 4 — chart podium, badges, animated micro-elements

### DIFF
--- a/app/src/main/java/com/suvojeet/suvmusic/ui/components/HomeSections.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/components/HomeSections.kt
@@ -40,12 +40,16 @@ import com.suvojeet.suvmusic.core.model.HomeSection
 import com.suvojeet.suvmusic.core.model.PlaylistDisplayItem
 import com.suvojeet.suvmusic.core.model.Song
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.LocalFireDepartment
+import androidx.compose.material.icons.filled.Schedule
 import androidx.compose.material.icons.rounded.Bookmark
 import androidx.compose.material.icons.rounded.BookmarkBorder
 import androidx.compose.material.icons.rounded.MoreVert
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.outlined.Radio
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -68,6 +72,19 @@ fun HorizontalCarouselSection(
 ) {
     if (section.items.isEmpty()) return
 
+    // Chart-style title → render as a podium instead of a flat carousel.
+    if (isChartSection(section.title)) {
+        ChartPodiumSection(
+            section = section,
+            onSongClick = onSongClick,
+            onPlaylistClick = onPlaylistClick,
+            onAlbumClick = onAlbumClick,
+            onSongMoreClick = onSongMoreClick,
+            modifier = modifier
+        )
+        return
+    }
+
     val items = remember(section.items) {
         section.items.distinctBy { it.id }
     }
@@ -76,10 +93,15 @@ fun HorizontalCarouselSection(
         items.filterIsInstance<HomeItem.SongItem>().map { it.song }
     }
 
+    // Section-title cues drive per-card badges so "Recently played" / "Trending"
+    // rows stand apart from generic carousels.
+    val showRecentBadge = remember(section.title) { isRecentSection(section.title) }
+    val showTrendingBadge = remember(section.title) { isTrendingSection(section.title) }
+
     Column(modifier = modifier) {
         HomeSectionHeader(title = section.title)
         Spacer(modifier = Modifier.height(16.dp))
-        
+
         LazyRow(
             contentPadding = PaddingValues(horizontal = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp)
@@ -90,41 +112,91 @@ fun HorizontalCarouselSection(
                 contentType = { _, item -> item::class }
             ) { index, item ->
                 when (item) {
-                    is HomeItem.SongItem -> {
-                        HomeItemCard(
-                            item = item,
-                            onSongClick = onSongClick,
-                            onPlaylistClick = onPlaylistClick,
-                            onAlbumClick = onAlbumClick,
-                            sectionItems = items,
-                            onSongMoreClick = onSongMoreClick
-                        )
-                    }
-                    is HomeItem.PlaylistItem -> {
-                        HomeItemCard(
-                            item = item, 
-                            onSongClick = onSongClick, 
-                            onPlaylistClick = onPlaylistClick, 
-                            onAlbumClick = onAlbumClick,
-                            sectionItems = items,
-                            onSongMoreClick = onSongMoreClick
-                        )
-                    }
+                    is HomeItem.SongItem,
+                    is HomeItem.PlaylistItem,
                     is HomeItem.AlbumItem -> {
-                        HomeItemCard(
-                            item = item, 
-                            onSongClick = onSongClick, 
-                            onPlaylistClick = onPlaylistClick, 
-                            onAlbumClick = onAlbumClick,
-                            sectionItems = items,
-                            onSongMoreClick = onSongMoreClick
-                        )
+                        SectionCardWithBadge(
+                            showRecent = showRecentBadge,
+                            showTrending = showTrendingBadge
+                        ) {
+                            HomeItemCard(
+                                item = item,
+                                onSongClick = onSongClick,
+                                onPlaylistClick = onPlaylistClick,
+                                onAlbumClick = onAlbumClick,
+                                sectionItems = items,
+                                onSongMoreClick = onSongMoreClick
+                            )
+                        }
                     }
                     else -> {}
                 }
             }
         }
     }
+}
+
+/**
+ * Wraps a card with a small top-end status badge (clock for recent, flame for
+ * trending). Badges are a recognisable Spotify/Apple Music idiom — they tell
+ * the user *why* a row is here, not just *what* is in it.
+ */
+@Composable
+private fun SectionCardWithBadge(
+    showRecent: Boolean,
+    showTrending: Boolean,
+    content: @Composable () -> Unit
+) {
+    if (!showRecent && !showTrending) {
+        content()
+        return
+    }
+    Box {
+        content()
+        if (showTrending) {
+            CardCornerBadge(
+                tint = Color(0xFFFF5722),
+                background = Color(0xFFFFE0B2)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.LocalFireDepartment,
+                    contentDescription = "Trending",
+                    tint = Color(0xFFFF5722),
+                    modifier = Modifier.size(14.dp)
+                )
+            }
+        } else if (showRecent) {
+            CardCornerBadge(
+                tint = MaterialTheme.colorScheme.primary,
+                background = MaterialTheme.colorScheme.surface.copy(alpha = 0.92f)
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Schedule,
+                    contentDescription = "Recently played",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(14.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BoxScope.CardCornerBadge(
+    tint: Color,
+    background: Color,
+    icon: @Composable () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .align(Alignment.TopEnd)
+            .padding(8.dp)
+            .size(24.dp)
+            .clip(CircleShape)
+            .background(background)
+            .border(1.dp, tint.copy(alpha = 0.35f), CircleShape),
+        contentAlignment = Alignment.Center
+    ) { icon() }
 }
 
 @Composable
@@ -674,9 +746,44 @@ fun CommunityPlaylistCard(
             .clip(RoundedCornerShape(24.dp))
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .clickable { onPlaylistClick(item.playlist) }
-            .padding(16.dp)
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        // Cassette-tape leader stripe — repeating dashes pinned to the very
+        // top edge of the card. Anchors the community card visually as a
+        // mixtape sleeve, distinct from regular playlist cards.
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(8.dp)
+                .background(
+                    Brush.horizontalGradient(
+                        listOf(
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.28f),
+                            MaterialTheme.colorScheme.tertiary.copy(alpha = 0.28f),
+                            MaterialTheme.colorScheme.primary.copy(alpha = 0.28f)
+                        )
+                    )
+                )
+                .padding(horizontal = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            repeat(28) {
+                Box(
+                    modifier = Modifier
+                        .height(2.dp)
+                        .weight(1f)
+                        .background(
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f),
+                            RoundedCornerShape(50)
+                        )
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 16.dp, top = 18.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
             // Header
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 // Cover Art
@@ -1372,6 +1479,395 @@ fun PersonalizedMixCard(
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(end = discPeek)
             )
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Section-title heuristics — drive the per-section UI variations below. We
+// detect intent from the title because YouTube doesn't expose a "this is a
+// chart" flag; the hooks are kept conservative to avoid false positives.
+// -----------------------------------------------------------------------------
+
+private fun isChartSection(title: String): Boolean {
+    val t = title.lowercase().trim()
+    return t.contains("chart") ||
+        t.contains("billboard") ||
+        t.contains("hot 100") ||
+        t.contains("hot 50") ||
+        t.contains("top hits") ||
+        t.contains("top songs") ||
+        t.contains("top tracks") ||
+        t.contains("top music videos") ||
+        t.contains("global top") ||
+        t.contains("weekly top") ||
+        Regex("\\b(top|hot)\\s*\\d+\\b").containsMatchIn(t)
+}
+
+private fun isRecentSection(title: String): Boolean {
+    val t = title.lowercase()
+    return t.contains("recent") ||
+        t.contains("listen again") ||
+        t.contains("history") ||
+        t.contains("last played") ||
+        t.contains("continue listening") ||
+        t.contains("jump back in") ||
+        t.contains("pick up where")
+}
+
+private fun isTrendingSection(title: String): Boolean {
+    val t = title.lowercase()
+    return t.contains("trending") ||
+        t.contains("rising") ||
+        t.contains("hot now") ||
+        t.contains("buzzing") ||
+        t.contains("on the rise") ||
+        t.contains("hot tracks")
+}
+
+// -----------------------------------------------------------------------------
+// Chart Podium — the explicitly-skipped phase 2/3 element. Auto-routed from
+// HorizontalCarouselSection when the title looks like a chart. Top-3 take a
+// medal podium (gold #1 in the centre, silver #2, bronze #3); ranks 4–10
+// fall through to a numbered list. Apple Music + Spotify chart hybrid.
+// -----------------------------------------------------------------------------
+
+private val ChartGold = Color(0xFFFFC83D)
+private val ChartSilver = Color(0xFFB8C6D1)
+private val ChartBronze = Color(0xFFCD7F32)
+
+@Composable
+fun ChartPodiumSection(
+    section: HomeSection,
+    onSongClick: (List<Song>, Int) -> Unit,
+    onPlaylistClick: (PlaylistDisplayItem) -> Unit,
+    onAlbumClick: (Album) -> Unit,
+    onSongMoreClick: (Song) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    val items = remember(section.items) { section.items.distinctBy { it.id } }
+    val songs = remember(items) {
+        items.filterIsInstance<HomeItem.SongItem>().map { it.song }
+    }
+
+    if (items.size < 3) {
+        // Not enough material for a podium; fall back to a plain header + list.
+        Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            HomeSectionHeader(title = section.title)
+            Column(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items.forEachIndexed { idx, item ->
+                    ChartListRow(
+                        item = item,
+                        rank = idx + 1,
+                        onClick = { dispatchItemClick(item, songs, onSongClick, onPlaylistClick, onAlbumClick) }
+                    )
+                }
+            }
+        }
+        return
+    }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(14.dp)
+    ) {
+        // Trophy-prefixed header — instantly reads as a chart.
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(30.dp)
+                    .clip(CircleShape)
+                    .background(ChartGold.copy(alpha = 0.20f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.EmojiEvents,
+                    contentDescription = null,
+                    tint = ChartGold,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+            Text(
+                text = section.title,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.ExtraBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                letterSpacing = (-0.4).sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        // Stage-gradient backdrop frames the podium so the row reads as a unit.
+        Box(
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(20.dp))
+                .background(
+                    Brush.verticalGradient(
+                        listOf(
+                            ChartGold.copy(alpha = 0.10f),
+                            MaterialTheme.colorScheme.surfaceContainer.copy(alpha = 0.0f)
+                        )
+                    )
+                )
+                .padding(vertical = 14.dp, horizontal = 10.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.Bottom
+            ) {
+                PodiumCard(
+                    item = items[1],
+                    rank = 2,
+                    accent = ChartSilver,
+                    isCenter = false,
+                    onClick = { dispatchItemClick(items[1], songs, onSongClick, onPlaylistClick, onAlbumClick) },
+                    modifier = Modifier.weight(1f)
+                )
+                PodiumCard(
+                    item = items[0],
+                    rank = 1,
+                    accent = ChartGold,
+                    isCenter = true,
+                    onClick = { dispatchItemClick(items[0], songs, onSongClick, onPlaylistClick, onAlbumClick) },
+                    modifier = Modifier.weight(1.18f)
+                )
+                PodiumCard(
+                    item = items[2],
+                    rank = 3,
+                    accent = ChartBronze,
+                    isCenter = false,
+                    onClick = { dispatchItemClick(items[2], songs, onSongClick, onPlaylistClick, onAlbumClick) },
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+
+        // Ranks 4–10 fall through as a numbered list — restraint after the podium.
+        val rest = items.drop(3).take(7)
+        if (rest.isNotEmpty()) {
+            Column(
+                modifier = Modifier.padding(horizontal = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                rest.forEachIndexed { idx, item ->
+                    ChartListRow(
+                        item = item,
+                        rank = idx + 4,
+                        onClick = { dispatchItemClick(item, songs, onSongClick, onPlaylistClick, onAlbumClick) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun dispatchItemClick(
+    item: HomeItem,
+    songs: List<Song>,
+    onSongClick: (List<Song>, Int) -> Unit,
+    onPlaylistClick: (PlaylistDisplayItem) -> Unit,
+    onAlbumClick: (Album) -> Unit
+) {
+    when (item) {
+        is HomeItem.SongItem -> {
+            val idx = songs.indexOf(item.song)
+            if (idx != -1) onSongClick(songs, idx)
+        }
+        is HomeItem.PlaylistItem -> onPlaylistClick(item.playlist)
+        is HomeItem.AlbumItem -> onAlbumClick(item.album)
+        else -> {}
+    }
+}
+
+@Composable
+private fun PodiumCard(
+    item: HomeItem,
+    rank: Int,
+    accent: Color,
+    isCenter: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val (title, subtitle, image) = when (item) {
+        is HomeItem.SongItem -> Triple(item.song.title, item.song.artist, item.song.thumbnailUrl)
+        is HomeItem.PlaylistItem -> Triple(item.playlist.name, item.playlist.uploaderName, item.playlist.thumbnailUrl)
+        is HomeItem.AlbumItem -> Triple(item.album.title, item.album.artist, item.album.thumbnailUrl)
+        else -> Triple("", "", null)
+    }
+    val coverHeight = if (isCenter) 156.dp else 124.dp
+
+    Column(
+        modifier = modifier.bounceClick(onClick = onClick),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(coverHeight)
+                .clip(RoundedCornerShape(14.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant)
+        ) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(image)
+                    .crossfade(true)
+                    .build(),
+                contentDescription = title,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+
+            // Medal-colored accent bar pinned to the top edge.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .height(4.dp)
+                    .background(accent)
+            )
+
+            // Big rank chip — sits over the cover so the position is unmistakable.
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(8.dp)
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(Color.Black.copy(alpha = 0.62f))
+                    .padding(horizontal = 9.dp, vertical = 3.dp)
+            ) {
+                Text(
+                    text = "#$rank",
+                    style = if (isCenter) MaterialTheme.typography.titleMedium else MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = accent,
+                    letterSpacing = (-0.4).sp
+                )
+            }
+
+            // Crown indicator sits in the trailing-top corner of #1 only.
+            if (isCenter) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(8.dp)
+                        .size(26.dp)
+                        .clip(CircleShape)
+                        .background(accent),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.EmojiEvents,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(15.dp)
+                    )
+                }
+            }
+        }
+
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+        if (!subtitle.isNullOrBlank()) {
+            Text(
+                text = subtitle,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChartListRow(
+    item: HomeItem,
+    rank: Int,
+    onClick: () -> Unit
+) {
+    val context = LocalContext.current
+    val (title, subtitle, image) = when (item) {
+        is HomeItem.SongItem -> Triple(item.song.title, item.song.artist, item.song.thumbnailUrl)
+        is HomeItem.PlaylistItem -> Triple(item.playlist.name, item.playlist.uploaderName, item.playlist.thumbnailUrl)
+        is HomeItem.AlbumItem -> Triple(item.album.title, item.album.artist, item.album.thumbnailUrl)
+        else -> Triple("", "", null)
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .padding(vertical = 6.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        // Bold ghosted rank numeral at the leading edge — pure Spotify "Top
+        // Songs" idiom. Heavy weight, low alpha, fixed width so all rows align.
+        Text(
+            text = rank.toString(),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Black,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.32f),
+            letterSpacing = (-1).sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.width(36.dp)
+        )
+
+        AsyncImage(
+            model = ImageRequest.Builder(context)
+                .data(image)
+                .crossfade(true)
+                .build(),
+            contentDescription = title,
+            modifier = Modifier
+                .size(48.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+            contentScale = ContentScale.Crop
+        )
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (!subtitle.isNullOrBlank()) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/screens/HomeScreen.kt
@@ -1331,9 +1331,13 @@ private fun LoadingMoreIndicator(modifier: Modifier = Modifier) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            LoadingIndicator(
-                modifier = Modifier.size(24.dp),
-                color = MaterialTheme.colorScheme.primary
+            // Dancing equalizer bars instead of a generic spinner — feels
+            // like the app is "listening" while it loads more.
+            EqualizerGlyph(
+                barColor = MaterialTheme.colorScheme.primary,
+                barCount = 5,
+                height = 24.dp,
+                barWidth = 3.dp
             )
             Text(
                 text = "Loading more for you...",
@@ -1347,6 +1351,8 @@ private fun LoadingMoreIndicator(modifier: Modifier = Modifier) {
 
 /**
  * Detected mood banner — shows when the engine auto-detects the user's current mood.
+ * The leading badge animates a 4-bar equalizer so the banner feels live and
+ * "listening to you" instead of a static notification.
  */
 @Composable
 private fun DetectedMoodBanner(
@@ -1376,11 +1382,11 @@ private fun DetectedMoodBanner(
                     ),
                 contentAlignment = Alignment.Center
             ) {
-                Icon(
-                    imageVector = Icons.Default.AutoAwesome,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.tertiary,
-                    modifier = Modifier.size(18.dp)
+                EqualizerGlyph(
+                    barColor = MaterialTheme.colorScheme.tertiary,
+                    barCount = 4,
+                    height = 18.dp,
+                    barWidth = 2.5.dp
                 )
             }
 
@@ -1705,6 +1711,11 @@ private fun ForYouBanner(
         color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.35f)
     ) {
         Box(modifier = Modifier.fillMaxWidth()) {
+            // Drifting-sparkle backdrop — six deterministically-placed dots
+            // gently float up and fade. Adds the "personalized magic" feel
+            // without any per-item layout cost.
+            DriftingSparkles()
+
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -2000,6 +2011,124 @@ fun TrackCard(
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(20.dp)
+            )
+        }
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Animated micro-elements — used by Phase-4 Detected Mood / For You banners and
+// the LoadingMore indicator.
+// -----------------------------------------------------------------------------
+
+/**
+ * Vertical-bar audio equalizer. Each bar runs an out-of-phase animation so
+ * the row reads as live audio, not a generic spinner. Kept lightweight —
+ * one infinite-transition, all bars share its driver.
+ */
+@Composable
+private fun EqualizerGlyph(
+    barColor: Color,
+    barCount: Int,
+    height: androidx.compose.ui.unit.Dp,
+    barWidth: androidx.compose.ui.unit.Dp,
+    modifier: Modifier = Modifier
+) {
+    val transition = rememberInfiniteTransition(label = "equalizer")
+    // Per-bar phase offsets give the dance an organic, non-mechanical feel.
+    val phases = remember(barCount) {
+        when (barCount) {
+            3 -> floatArrayOf(0f, 0.33f, 0.66f)
+            4 -> floatArrayOf(0f, 0.25f, 0.5f, 0.75f)
+            5 -> floatArrayOf(0f, 0.2f, 0.6f, 0.4f, 0.8f)
+            else -> FloatArray(barCount) { it.toFloat() / barCount }
+        }
+    }
+    val durations = remember(barCount) {
+        when (barCount) {
+            3 -> intArrayOf(620, 540, 700)
+            4 -> intArrayOf(620, 540, 700, 580)
+            5 -> intArrayOf(620, 540, 700, 580, 660)
+            else -> IntArray(barCount) { 580 + (it % 3) * 60 }
+        }
+    }
+
+    Row(
+        modifier = modifier.height(height),
+        horizontalArrangement = Arrangement.spacedBy(barWidth * 0.7f),
+        verticalAlignment = Alignment.Bottom
+    ) {
+        for (i in 0 until barCount) {
+            val anim by transition.animateFloat(
+                initialValue = 0.25f,
+                targetValue = 1f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(
+                        durationMillis = durations[i],
+                        easing = androidx.compose.animation.core.FastOutSlowInEasing,
+                        delayMillis = (phases[i] * 400f).toInt()
+                    ),
+                    repeatMode = RepeatMode.Reverse
+                ),
+                label = "bar$i"
+            )
+            Box(
+                modifier = Modifier
+                    .width(barWidth)
+                    .fillMaxHeight(anim)
+                    .clip(RoundedCornerShape(50))
+                    .background(barColor)
+            )
+        }
+    }
+}
+
+/**
+ * Six deterministically-placed sparkle dots that drift up + fade across the
+ * For-You banner. Backdrop only — sits behind the banner content. No layout
+ * cost because each dot is just a styled Box.
+ */
+@Composable
+private fun DriftingSparkles(modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "sparkles")
+    // Each sparkle: (x-fraction, base y-fraction, period-ms, size-dp, alpha-mul).
+    val sparks = remember {
+        listOf(
+            Triple(0.12f, 0.65f, 2400),
+            Triple(0.28f, 0.20f, 3100),
+            Triple(0.46f, 0.78f, 2700),
+            Triple(0.62f, 0.32f, 2950),
+            Triple(0.78f, 0.70f, 2300),
+            Triple(0.90f, 0.18f, 3300)
+        )
+    }
+    val tint = MaterialTheme.colorScheme.primary
+    Box(modifier = modifier.fillMaxSize()) {
+        sparks.forEachIndexed { idx, (x, y, ms) ->
+            val drift by transition.animateFloat(
+                initialValue = 0f,
+                targetValue = 1f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(
+                        durationMillis = ms,
+                        easing = LinearEasing,
+                        delayMillis = (idx * 240) % ms
+                    ),
+                    repeatMode = RepeatMode.Restart
+                ),
+                label = "spark$idx"
+            )
+            // Drift upward by ~14dp and fade out as it nears the top.
+            val verticalOffset = (-14f * drift).dp
+            val alpha = (1f - drift).coerceAtLeast(0f) * 0.55f
+            val size = (3 + (idx % 3)).dp
+            Box(
+                modifier = Modifier
+                    .padding(start = (x * 320).dp, top = (y * 80).dp)
+                    .offset(y = verticalOffset)
+                    .size(size)
+                    .clip(CircleShape)
+                    .background(tint.copy(alpha = alpha))
             )
         }
     }


### PR DESCRIPTION
## Summary

Continues the home redesign on a fresh branch. Builds on phases 1–3 by tackling the explicitly-skipped Charts/Top 50 podium and adding three families of section-level cues so the feed reads as varied content, not just varied silhouettes.

## What changed

**P4.1 — Chart podium for Top/Charts/Hot sections**
\`isChartSection(title)\` is a conservative title heuristic (chart, billboard, hot 100/50, top hits/songs/tracks, regex \`top|hot \d+\`). When it matches, \`HorizontalCarouselSection\` re-routes to a new \`ChartPodiumSection\`: trophy-prefixed header, gold/silver/bronze podium cards with the centre #1 sitting taller, gold crown badge on the leader, then ranks 4–10 fall through as a Spotify-style numbered list (heavy ghosted numerals at the leading edge). All three callers picked it up automatically through the single-entry-point dispatch.

**P4.2 — Per-card status badges**
\`isRecentSection()\` / \`isTrendingSection()\` heuristics drive a small top-end badge on every card in the carousel:
- **Trending** → flame on amber (\`LocalFireDepartment\`)
- **Recently played** → clock on a frosted disc (\`Schedule\`)

Implemented as a \`SectionCardWithBadge\` wrapper so \`HomeItemCard\` stays untouched. Badges only mount when the section title qualifies, so generic carousels are unchanged.

**P4.3 — Cassette-tape stripe on Community card**
The phase-2/3 list noted Community was "already differentiated", so this is a light touch — 8dp top edge with a primary→tertiary horizontal gradient and 28 thin dashes overlaid so the silhouette reads as a mixtape sleeve.

**P4.4 — Animated micro-elements**
- \`EqualizerGlyph\`: 3/4/5 dancing bars, per-bar phase + duration offsets so the row reads as live audio. Replaces the static \`AutoAwesome\` icon in \`DetectedMoodBanner\` and the plain spinner in \`LoadingMoreIndicator\`.
- \`DriftingSparkles\`: six deterministically-positioned dots that drift up + fade across the \`ForYouBanner\`. Pure backdrop, no layout cost.

## Files touched
- \`HomeSections.kt\` — chart-podium component, helpers, badge wrapper, cassette stripe on \`CommunityPlaylistCard\`
- \`HomeScreen.kt\` — equalizer in \`DetectedMoodBanner\` + \`LoadingMoreIndicator\`, drifting sparkles in \`ForYouBanner\`

## Test plan
- [x] Wait for CI Debug Build to pass
- [x] Install on device, scroll Home: confirm Top 50 / Charts sections render the podium with #1 centred and ranks 4–10 as a numbered list
- [x] Pull-to-refresh / scroll-load: confirm equalizer-bar loading indicator instead of spinner
- [x] Detected mood banner: confirm 4-bar equalizer dances in the leading badge
- [x] For You banner (when logged in): confirm subtle sparkles drift behind the row
- [x] Trending / Rising / Hot now sections: confirm flame badge in card top-right
- [x] Recently played / Listen again sections: confirm clock badge
- [x] Community Carousel: confirm cassette tape stripe at the top edge