### PR TITLE
Flat YouTube-Music-style player + queue redesign

### DIFF
--- a/app/src/main/java/com/suvojeet/suvmusic/data/SessionManager.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/data/SessionManager.kt
@@ -690,11 +690,11 @@ class SessionManager @Inject constructor(
         }
     }
     
-    suspend fun getSeekbarStyle(): String = 
-        context.dataStore.data.first()[SEEKBAR_STYLE_KEY] ?: "M3E_WAVY"
-    
+    suspend fun getSeekbarStyle(): String =
+        context.dataStore.data.first()[SEEKBAR_STYLE_KEY] ?: "MATERIAL"
+
     val seekbarStyleFlow: Flow<String> = context.dataStore.data.map { preferences ->
-        preferences[SEEKBAR_STYLE_KEY] ?: "M3E_WAVY"
+        preferences[SEEKBAR_STYLE_KEY] ?: "MATERIAL"
     }
     
     suspend fun setSeekbarStyle(style: String) {

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/PlayerScreen.kt
@@ -201,12 +201,12 @@ fun PlayerScreen(
     val animatedBackgroundEnabled by sessionManager.playerAnimatedBackgroundFlow.collectAsStateWithLifecycle(initialValue = true)
     val currentArtworkShapeName by sessionManager.artworkShapeFlow.collectAsStateWithLifecycle(initialValue = ArtworkShape.ROUNDED_SQUARE.name)
     val currentArtworkSizeName by sessionManager.artworkSizeFlow.collectAsStateWithLifecycle(initialValue = ArtworkSize.LARGE.name)
-    val currentSeekbarStyleName by sessionManager.seekbarStyleFlow.collectAsStateWithLifecycle(initialValue = SeekbarStyle.WAVEFORM.name)
+    val currentSeekbarStyleName by sessionManager.seekbarStyleFlow.collectAsStateWithLifecycle(initialValue = SeekbarStyle.MATERIAL.name)
     val volumeSliderEnabled by sessionManager.volumeSliderEnabledFlow.collectAsStateWithLifecycle(initialValue = true)
     val playerGlassBlur by sessionManager.playerGlassBlurFlow.collectAsStateWithLifecycle(initialValue = 60f)
     val playerGlassIntensity by sessionManager.playerGlassIntensityFlow.collectAsStateWithLifecycle(initialValue = 1f)
     val audioArEnabled by sessionManager.audioArEnabledFlow.collectAsStateWithLifecycle(initialValue = false)
-    val rotatingVinylAnimationEnabled by sessionManager.rotatingVinylAnimationEnabledFlow.collectAsStateWithLifecycle(initialValue = true)
+    val rotatingVinylAnimationEnabled by sessionManager.rotatingVinylAnimationEnabledFlow.collectAsStateWithLifecycle(initialValue = false)
     
     val themeMode by sessionManager.themeModeFlow.collectAsStateWithLifecycle(initialValue = ThemeMode.SYSTEM)
     val isAppInDarkTheme = when (themeMode) {
@@ -235,7 +235,7 @@ fun PlayerScreen(
 
     val currentArtworkShape = try { ArtworkShape.valueOf(currentArtworkShapeName) } catch (e: Exception) { ArtworkShape.ROUNDED_SQUARE }
     val currentArtworkSize = try { ArtworkSize.valueOf(currentArtworkSizeName) } catch (e: Exception) { ArtworkSize.LARGE }
-    val currentSeekbarStyle = try { SeekbarStyle.valueOf(currentSeekbarStyleName) } catch (e: Exception) { SeekbarStyle.WAVEFORM }
+    val currentSeekbarStyle = try { SeekbarStyle.valueOf(currentSeekbarStyleName) } catch (e: Exception) { SeekbarStyle.MATERIAL }
 
     val view = LocalView.current
     val coroutineScope = rememberCoroutineScope()
@@ -346,13 +346,29 @@ fun PlayerScreen(
         com.suvojeet.suvmusic.ui.screens.player.components.LocalCurrentDownloadProgress provides currentDownloadProgress
       ) {
         Box(modifier = Modifier.fillMaxSize().background(playerBackgroundColor).graphicsLayer { alpha = bgLoadingAlpha }) {
-            // Background — skip the mesh gradient for Liquid Glass; it draws its own blurred backdrop.
-            if (playerStyle == PlayerStyle.LIQUID_GLASS) {
-                // intentional: LiquidGlassPlayerStyle draws its own full-screen backdrop.
-            } else if (animatedBackgroundEnabled && !playerState.isVideoMode) {
-                MeshGradientBackground(dominantColors = dominantColors, backgroundColor = playerBackgroundColor)
-            } else {
-                Box(modifier = Modifier.fillMaxSize().background(Brush.verticalGradient(colors = listOf(dominantColors.secondary, dominantColors.primary, playerBackgroundColor))))
+            // Background is style-specific:
+            //  • LIQUID_GLASS draws its own full-screen blurred backdrop — skip here.
+            //  • YT_MUSIC uses the flat YouTube-Music look: solid surface + a subtle blurred
+            //    album-art wash, no decorative gradients (app-wide default).
+            //  • CLASSIC keeps the original animated mesh / vertical color gradient.
+            when (playerStyle) {
+                PlayerStyle.LIQUID_GLASS -> {
+                    // intentional: LiquidGlassPlayerStyle draws its own full-screen backdrop.
+                }
+                PlayerStyle.YT_MUSIC -> {
+                    com.suvojeet.suvmusic.ui.screens.player.components.FlatArtTintBackground(
+                        thumbnailUrl = song?.thumbnailUrl,
+                        isDarkTheme = isAppInDarkTheme,
+                        isVideoMode = playerState.isVideoMode
+                    )
+                }
+                PlayerStyle.CLASSIC -> {
+                    if (animatedBackgroundEnabled && !playerState.isVideoMode) {
+                        MeshGradientBackground(dominantColors = dominantColors, backgroundColor = playerBackgroundColor)
+                    } else {
+                        Box(modifier = Modifier.fillMaxSize().background(Brush.verticalGradient(colors = listOf(dominantColors.secondary, dominantColors.primary, playerBackgroundColor))))
+                    }
+                }
             }
 
             val playerMainContent: @Composable () -> Unit = {

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/FlatArtTintBackground.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/FlatArtTintBackground.kt
@@ -1,0 +1,90 @@
+package com.suvojeet.suvmusic.ui.screens.player.components
+
+import android.os.Build
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asComposeRenderEffect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.suvojeet.suvmusic.ui.theme.YtFlatBackground
+
+/**
+ * Flat, YouTube-Music-style player backdrop.
+ *
+ * Three fully static layers (no infinite/animated state — strictly cheaper than the
+ * [com.suvojeet.suvmusic.ui.components.MeshGradientBackground] it replaces for the YT_MUSIC
+ * style, which ran eight infinite float animations). It recomposes only when the song,
+ * theme, or video-mode flag changes:
+ *
+ *  1. A solid base fill ([YtFlatBackground] in dark, white in light).
+ *  2. A *subtle* blurred album-art wash (skipped in video mode / when no art is available).
+ *  3. A single-color vertical scrim so the top is faintly washed and the bottom is fully
+ *     flat — this is a scrim of one base color, not a decorative multi-color gradient.
+ *
+ * The blur is SDK-gated exactly like
+ * [com.suvojeet.suvmusic.ui.screens.player.styles.LiquidGlassPlayerStyle]: hardware
+ * [android.graphics.RenderEffect] on API 31+, falling back to [blur] below it (minSdk 26).
+ */
+@Composable
+fun FlatArtTintBackground(
+    thumbnailUrl: String?,
+    isDarkTheme: Boolean,
+    isVideoMode: Boolean,
+    modifier: Modifier = Modifier
+) {
+    val base = if (isDarkTheme) YtFlatBackground else Color.White
+    val artAlpha = if (isDarkTheme) 0.18f else 0.10f
+
+    Box(modifier = modifier.fillMaxSize().background(base)) {
+        // Layer 2 — subtle blurred album-art wash (audio-only).
+        if (!thumbnailUrl.isNullOrBlank() && !isVideoMode) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .then(
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                            Modifier.graphicsLayer {
+                                renderEffect = android.graphics.RenderEffect.createBlurEffect(
+                                    80f,
+                                    80f,
+                                    android.graphics.Shader.TileMode.CLAMP
+                                ).asComposeRenderEffect()
+                            }
+                        } else {
+                            Modifier.blur(40.dp)
+                        }
+                    )
+            ) {
+                AsyncImage(
+                    model = thumbnailUrl,
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize().graphicsLayer { alpha = artAlpha },
+                    contentScale = ContentScale.Crop
+                )
+            }
+        }
+
+        // Layer 3 — single-color scrim: faint at the top, solid at the bottom.
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            base.copy(alpha = 0.55f),
+                            base.copy(alpha = 0.85f),
+                            base
+                        )
+                    )
+                )
+        )
+    }
+}

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerArtwork.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerArtwork.kt
@@ -134,7 +134,8 @@ fun AlbumArtwork(
             hueShift,
         ).copy(alpha = pulseAlpha)
     } else {
-        dominantColors.primary.copy(alpha = 0.5f)
+        // Flat YT-Music look: keep only a faint art-colored glow, not a heavy halo.
+        dominantColors.primary.copy(alpha = 0.25f)
     }
 
     // Shape state - uses initial shape from settings
@@ -278,7 +279,7 @@ fun AlbumArtwork(
                         rotationZ = rotation + currentRotation
                     }
                     .shadow(
-                        elevation = if (colorFlashingEnabled && isPlaying) 28.dp else 16.dp,
+                        elevation = if (colorFlashingEnabled && isPlaying) 28.dp else 8.dp,
                         shape = RoundedCornerShape(safeCornerRadius),
                         spotColor = glowColor,
                         ambientColor = glowColor

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerBottomActions.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerBottomActions.kt
@@ -194,7 +194,7 @@ private fun BottomTabButton(
             style = MaterialTheme.typography.labelLarge,
             color = if (enabled) dominantColors.onBackground.copy(alpha = 0.8f) else dominantColors.onBackground.copy(alpha = 0.3f),
             fontWeight = FontWeight.Bold,
-            letterSpacing = 1.sp
+            letterSpacing = 0.5.sp
         )
     }
 }

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerControls.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerControls.kt
@@ -88,7 +88,7 @@ fun PlaybackControls(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(dominantColors.onBackground.copy(alpha = 0.1f), CircleShape),
+                    .background(dominantColors.onBackground.copy(alpha = 0.08f), CircleShape),
                 contentAlignment = Alignment.Center
             ) {
                 AnimatedContent(

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerSongInfo.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerSongInfo.kt
@@ -164,7 +164,7 @@ fun SongInfoSection(
                     Row(
                         modifier = Modifier
                             .clip(CircleShape)
-                            .background(dominantColors.onBackground.copy(alpha = 0.08f))
+                            .background(dominantColors.onBackground.copy(alpha = 0.06f))
                             .padding(horizontal = 2.dp, vertical = 2.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerTopBar.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerTopBar.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.suvojeet.suvmusic.ui.components.DominantColors
-import com.suvojeet.suvmusic.ui.theme.SquircleShape
 
 @Composable
 fun PlayerTopBar(
@@ -55,8 +54,8 @@ fun PlayerTopBar(
             modifier = Modifier
                 .align(Alignment.CenterStart)
                 .size(44.dp)
-                .clip(SquircleShape)
-                .background(dominantColors.onBackground.copy(alpha = 0.1f))
+                .clip(CircleShape)
+                .background(dominantColors.onBackground.copy(alpha = 0.07f))
                 .clickable(onClick = onBack),
             contentAlignment = Alignment.Center
         ) {
@@ -79,7 +78,7 @@ fun PlayerTopBar(
                     modifier = Modifier
                         .wrapContentSize()
                         .clip(CircleShape)
-                        .background(dominantColors.onBackground.copy(alpha = 0.12f))
+                        .background(dominantColors.onBackground.copy(alpha = 0.08f))
                         .padding(4.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(4.dp)
@@ -89,7 +88,7 @@ fun PlayerTopBar(
                         modifier = Modifier
                             .size(36.dp)
                             .clip(CircleShape)
-                            .background(if (!isVideoMode) dominantColors.onBackground.copy(alpha = 0.18f) else Color.Transparent)
+                            .background(if (!isVideoMode) dominantColors.onBackground.copy(alpha = 0.14f) else Color.Transparent)
                             .clickable { if (isVideoMode) onVideoToggle() },
                         contentAlignment = Alignment.Center
                     ) {
@@ -106,7 +105,7 @@ fun PlayerTopBar(
                         modifier = Modifier
                             .size(36.dp)
                             .clip(CircleShape)
-                            .background(if (isVideoMode) dominantColors.onBackground.copy(alpha = 0.18f) else Color.Transparent)
+                            .background(if (isVideoMode) dominantColors.onBackground.copy(alpha = 0.14f) else Color.Transparent)
                             .clickable { if (!isVideoMode) onVideoToggle() },
                         contentAlignment = Alignment.Center
                     ) {
@@ -139,8 +138,8 @@ fun PlayerTopBar(
             Box(
                 modifier = Modifier
                     .size(44.dp)
-                    .clip(SquircleShape)
-                    .background(dominantColors.onBackground.copy(alpha = 0.1f))
+                    .clip(CircleShape)
+                    .background(dominantColors.onBackground.copy(alpha = 0.07f))
                     .clickable(onClick = onCastClick),
                 contentAlignment = Alignment.Center
             ) {
@@ -157,8 +156,8 @@ fun PlayerTopBar(
                 Box(
                     modifier = Modifier
                         .size(44.dp)
-                        .clip(SquircleShape)
-                        .background(dominantColors.onBackground.copy(alpha = 0.1f))
+                        .clip(CircleShape)
+                        .background(dominantColors.onBackground.copy(alpha = 0.07f))
                         .clickable(onClick = onRecenter),
                     contentAlignment = Alignment.Center
                 ) {
@@ -176,8 +175,8 @@ fun PlayerTopBar(
             Box(
                 modifier = Modifier
                     .size(44.dp)
-                    .clip(SquircleShape)
-                    .background(dominantColors.onBackground.copy(alpha = 0.1f))
+                    .clip(CircleShape)
+                    .background(dominantColors.onBackground.copy(alpha = 0.07f))
                     .clickable(onClick = onMoreClick),
                 contentAlignment = Alignment.Center
             ) {

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/QueueScreenUI.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/QueueScreenUI.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
@@ -93,7 +92,8 @@ fun ModernQueueView(
     val isSelectionMode = selectedQueueIndices.isNotEmpty()
     val scope = rememberCoroutineScope()
     
-    val backgroundColor = if (isDarkTheme) Color.Black else MaterialTheme.colorScheme.surface
+    // Flat YouTube-Music-style queue: a single solid surface, no color-tint gradient.
+    val backgroundColor = if (isDarkTheme) com.suvojeet.suvmusic.ui.theme.YtFlatBackground else MaterialTheme.colorScheme.surface
     val contentColor = if (isDarkTheme) Color.White else Color.Black
     val secondaryContentColor = contentColor.copy(alpha = 0.6f)
 
@@ -102,20 +102,6 @@ fun ModernQueueView(
             .fillMaxSize()
             .background(backgroundColor)
     ) {
-        // Gradient Overlay for subtle color tint
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(
-                    Brush.verticalGradient(
-                        colors = listOf(
-                            dominantColors.primary.copy(alpha = if (isDarkTheme) 0.15f else 0.1f),
-                            backgroundColor
-                        )
-                    )
-                )
-        )
-
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/theme/Color.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/theme/Color.kt
@@ -81,6 +81,9 @@ val SurfaceContainer = Color(0xFF211E26)
 val SurfaceContainerHigh = Color(0xFF2C2930)
 val SurfaceContainerHighest = Color(0xFF37343B)
 
+// Flat YouTube-Music-style player base (near-black, slightly lifted off pure #000)
+val YtFlatBackground = Color(0xFF0F0F0F)
+
 // Glassmorphism
 val GlassWhite = Color(0x1AFFFFFF)
 val GlassBlack = Color(0x33000000)


### PR DESCRIPTION
## What
First pass of the YT-Music-style redesign, scoped to the **Now-Playing player + Queue** (Home/nav are a later pass).

Makes the flat "YouTube Music latest" look the **app-wide default** (the default player style is already `YT_MUSIC`). `Classic` and `Liquid Glass` styles are untouched, and **no composable signatures changed**.

## Changes
- **New `FlatArtTintBackground`** — solid dark surface + a *subtle* blurred album-art wash (audio-only) + a single-color scrim. Fully static (no infinite animations, unlike the mesh gradient it replaces) and receives only `isVideoMode`, so it recomposes only on song/theme/video changes.
- **`PlayerScreen` background** → per-style `when()`: `YT_MUSIC` uses the flat backdrop, `CLASSIC` keeps the mesh/gradient, `LIQUID_GLASS` unchanged.
- **Seekbar default → `MATERIAL`** (thin line + round thumb) and **rotating-vinyl initial → off**, matching the flat look. Existing user choices persist via DataStore.
- **Queue** — removed the vertical color-tint gradient overlay; solid `0xFF0F0F0F` base. Drag-reorder / selection logic unchanged.
- **Flattened surfaces** — top bar (round buttons, lower alphas), artwork shadow/glow, like capsule, play-button ring.

## Notes / risks
- Blur is SDK-gated like `LiquidGlassPlayerStyle` (RenderEffect on API 31+, else `Modifier.blur`); minSdk 26 degrades to low-alpha non-blurred art.
- Background sits outside `SupportingPaneScaffold`, so it covers portrait, landscape, and tablet panes.
- Not built locally (device thermals) — relying on CI.