### PR TITLE
fix(playback): close stream-resolution gaps that broke seamless playback

### DIFF
--- a/app/src/main/java/com/suvojeet/suvmusic/data/repository/RemoteAudioRepository.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/data/repository/RemoteAudioRepository.kt
@@ -32,11 +32,46 @@ class RemoteAudioRepository @Inject constructor(
     private val gson: Gson,
     private val apiService: com.suvojeet.suvmusic.data.repository.remote.RemoteAudioApiService
 ) {
-    // In-memory caches to reduce server load and improve performance
-    private val searchCache = mutableMapOf<String, List<Song>>()
-    private val songDetailsCache = mutableMapOf<String, Song>()
-    private val streamUrlCache = mutableMapOf<String, String>()
-    private val playlistCache = mutableMapOf<String, Playlist>()
+    // In-memory caches to reduce server load and improve performance.
+    // Bounded (LRU) so a long session can't leak memory by growing forever; the
+    // least-recently-used entry is evicted past the cap. Thread-safe because these
+    // are touched from multiple Dispatchers.IO coroutines concurrently.
+    private fun <V> boundedCache(maxSize: Int): MutableMap<String, V> =
+        java.util.Collections.synchronizedMap(
+            object : LinkedHashMap<String, V>(16, 0.75f, true) {
+                override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, V>): Boolean = size > maxSize
+            }
+        )
+
+    private val searchCache = boundedCache<List<Song>>(80)
+    private val songDetailsCache = boundedCache<Song>(300)
+    private val streamUrlCache = boundedCache<String>(300)
+    private val playlistCache = boundedCache<Playlist>(60)
+
+    // Per-call timeout for raw HTTP requests. Shares the connection pool/dispatcher
+    // with the injected client (newBuilder is cheap) but caps total call time so a
+    // stalled legacy endpoint can't hang a resolve/prefetch indefinitely.
+    private val boundedHttpClient: OkHttpClient by lazy {
+        okHttpClient.newBuilder()
+            .callTimeout(20, java.util.concurrent.TimeUnit.SECONDS)
+            .build()
+    }
+
+    /**
+     * Drop any cached stream URL / song details for [songId] so the next resolve
+     * re-fetches from the backend. Called by the player when a stream URL dies
+     * (HTTP 403/410) mid-playback — without this the cache would keep handing back
+     * the same dead URL and playback could never recover.
+     */
+    fun invalidate(songId: String) {
+        synchronized(streamUrlCache) {
+            streamUrlCache.keys
+                .filter { it == songId || it.startsWith("${songId}_") }
+                .toList()
+                .forEach { streamUrlCache.remove(it) }
+        }
+        songDetailsCache.remove(songId)
+    }
 
     // --- 429 rate-limit backoff (shared across ALL RemoteAudio network calls) ---
     // The backend rate-limits aggressively, and the app used to fire many calls at once
@@ -167,13 +202,17 @@ class RemoteAudioRepository @Inject constructor(
      * Search for artists on RemoteAudio (Legacy fallback for rich profiles).
      */
     suspend fun searchArtists(query: String): List<com.suvojeet.suvmusic.core.model.Artist> = withContext(Dispatchers.IO) {
+        if (isRateLimited()) {
+            android.util.Log.w("RemoteAudio", "searchArtists('$query') SKIP backoff active")
+            return@withContext emptyList()
+        }
         try {
             val url = "$BASE_URL?${RemoteConstants.PARAM_CALL}${RemoteConstants.EP_SEARCH_ARTIST}&_format=json&n=5&q=${query.encodeUrl()}"
             val response = makeRequest(url)
-            
+
             val json = JsonParser.parseString(response).asJsonObject
             val results = json.getAsJsonArray("results") ?: return@withContext emptyList()
-            
+
             results.mapNotNull { element ->
                 val artist = element.asJsonObject
                 val id = artist.get("id")?.asString ?: return@mapNotNull null
@@ -187,14 +226,19 @@ class RemoteAudioRepository @Inject constructor(
                 )
             }
         } catch (e: Exception) {
+            android.util.Log.e("RemoteAudio", "searchArtists('$query') failed: ${e.javaClass.simpleName}: ${e.message}")
             emptyList()
         }
     }
-    
+
     /**
      * Get detailed artist profile (Legacy internal API).
      */
     suspend fun getArtist(artistId: String): com.suvojeet.suvmusic.core.model.Artist? = withContext(Dispatchers.IO) {
+        if (isRateLimited()) {
+            android.util.Log.w("RemoteAudio", "getArtist($artistId) SKIP backoff active")
+            return@withContext null
+        }
         try {
             val url = "$BASE_URL?${RemoteConstants.PARAM_CALL}${RemoteConstants.EP_WEBAPI_GET}&token=$artistId&type=artist&p=1&n_song=20&n_album=20&sub_type=songs&category=&sort_order=&includeMetaTags=0&ctx=web6dot0&api_version=4&_format=json&_marker=0"
             val response = makeRequest(url)
@@ -229,6 +273,7 @@ class RemoteAudioRepository @Inject constructor(
                 albums = topAlbums
             )
         } catch (e: Exception) {
+            android.util.Log.e("RemoteAudio", "getArtist($artistId) failed: ${e.javaClass.simpleName}: ${e.message}")
             null
         }
     }
@@ -288,36 +333,54 @@ class RemoteAudioRepository @Inject constructor(
      */
     suspend fun getStreamUrl(songId: String, quality: Int = 320): String? = withContext(Dispatchers.IO) {
         val cacheKey = "${songId}_$quality"
-        if (streamUrlCache.containsKey(cacheKey)) {
+        streamUrlCache[cacheKey]?.let {
             android.util.Log.i("RemoteAudio", ">> getStreamUrl ENTER vid=$songId q=$quality CACHE_HIT")
-            return@withContext streamUrlCache[cacheKey]
+            return@withContext it
+        }
+
+        // Don't even attempt while backing off from a 429 — the player would just
+        // re-trigger the throttle and stall waiting for a URL that won't come.
+        if (isRateLimited()) {
+            android.util.Log.w("RemoteAudio", ">> getStreamUrl SKIP vid=$songId q=$quality backoff active")
+            return@withContext null
         }
 
         android.util.Log.i("RemoteAudio", ">> getStreamUrl ENTER vid=$songId q=$quality")
-        val started = System.currentTimeMillis()
-        try {
-            val song = getSongDetails(songId)
-            val streamUrl = song?.streamUrl
-            val ms = System.currentTimeMillis() - started
+        // Retry transient failures (network blip / null) up to 2 attempts so a single
+        // hiccup doesn't stop playback. Parity with the YouTube path, which already retries.
+        val maxAttempts = 2
+        var lastError: Exception? = null
+        repeat(maxAttempts) { attempt ->
+            val started = System.currentTimeMillis()
+            try {
+                val song = getSongDetails(songId)
+                val streamUrl = song?.streamUrl
+                val ms = System.currentTimeMillis() - started
 
-            if (streamUrl.isNullOrBlank()) {
-                android.util.Log.e("RemoteAudio", "<< getStreamUrl EXIT vid=$songId NULL (details=${if (song == null) "null" else "ok but no streamUrl"}) in ${ms}ms")
-            } else {
-                android.util.Log.i("RemoteAudio", "<< getStreamUrl EXIT vid=$songId ok(${streamUrl.take(80)}) in ${ms}ms")
-                streamUrlCache[cacheKey] = streamUrl
+                if (streamUrl.isNullOrBlank()) {
+                    android.util.Log.e("RemoteAudio", "<< getStreamUrl vid=$songId NULL (attempt ${attempt + 1}/$maxAttempts, details=${if (song == null) "null" else "ok but no streamUrl"}) in ${ms}ms")
+                    // A genuinely blank stream URL won't change on retry — bail out.
+                    if (song != null) return@withContext null
+                } else {
+                    android.util.Log.i("RemoteAudio", "<< getStreamUrl EXIT vid=$songId ok(${streamUrl.take(80)}) in ${ms}ms")
+                    streamUrlCache[cacheKey] = streamUrl
+                    return@withContext streamUrl
+                }
+            } catch (e: Exception) {
+                lastError = e
+                if (is429(e)) { noteRateLimited(); return@withContext null }
+                val ms = System.currentTimeMillis() - started
+                android.util.Log.e("RemoteAudio", "<< getStreamUrl vid=$songId FAIL (attempt ${attempt + 1}/$maxAttempts) in ${ms}ms ${e.javaClass.simpleName}: ${e.message}")
             }
-            streamUrl
-        } catch (e: Exception) {
-            val ms = System.currentTimeMillis() - started
-            android.util.Log.e("RemoteAudio", "<< getStreamUrl EXIT vid=$songId FAIL in ${ms}ms ${e.javaClass.simpleName}: ${e.message}", e)
-            Telemetry.report("stream.resolve", "remoteaudio", e.toAppError(), mapOf("id" to songId))
-            null
+            if (attempt < maxAttempts - 1) kotlinx.coroutines.delay(800)
         }
+        lastError?.let { Telemetry.report("stream.resolve", "remoteaudio", it.toAppError(), mapOf("id" to songId)) }
+        null
     }
 
     // ==================== Radio / Related / Recommendations ====================
 
-    private val relatedCache = mutableMapOf<String, List<Song>>()
+    private val relatedCache = boundedCache<List<Song>>(80)
 
     /**
      * Get songs related to [songId] using RemoteAudio's recommendation endpoint.
@@ -396,12 +459,16 @@ class RemoteAudioRepository @Inject constructor(
      * Get playlist details with all songs.
      */
     suspend fun getPlaylist(playlistId: String): Playlist? = withContext(Dispatchers.IO) {
-        if (playlistCache.containsKey(playlistId)) {
-            return@withContext playlistCache[playlistId]
+        playlistCache[playlistId]?.let { return@withContext it }
+
+        if (isRateLimited()) {
+            android.util.Log.w("RemoteAudio", "getPlaylist($playlistId) SKIP backoff active")
+            return@withContext null
         }
 
         try {
             val response = apiService.getPlaylist(playlistId)
+            noteSuccess()
             val data = response.data
 
             // In some wrapper versions, playlist info might be in 'playlists' or direct 'name/id' fields
@@ -424,6 +491,7 @@ class RemoteAudioRepository @Inject constructor(
             playlistCache[playlistId] = playlist
             playlist
         } catch (e: Exception) {
+            if (is429(e)) noteRateLimited()
             android.util.Log.e("RemoteAudio", "getPlaylist($playlistId) failed: ${e.message}")
             null
         }
@@ -433,8 +501,13 @@ class RemoteAudioRepository @Inject constructor(
      * Get album details with all songs.
      */
     suspend fun getAlbum(albumId: String): Playlist? = withContext(Dispatchers.IO) {
+        if (isRateLimited()) {
+            android.util.Log.w("RemoteAudio", "getAlbum($albumId) SKIP backoff active")
+            return@withContext null
+        }
         try {
             val response = apiService.getAlbumDetails(albumId)
+            noteSuccess()
             val songs = response.data?.mapNotNull { parseSongDto(it) } ?: emptyList()
             
             if (songs.isEmpty()) return@withContext null
@@ -452,6 +525,7 @@ class RemoteAudioRepository @Inject constructor(
                 songs = songs
             )
         } catch (e: Exception) {
+            if (is429(e)) noteRateLimited()
             android.util.Log.e("RemoteAudio", "getAlbum($albumId) failed: ${e.message}")
             null
         }
@@ -918,7 +992,12 @@ class RemoteAudioRepository @Inject constructor(
      */
     suspend fun getFeaturedPlaylists(): List<com.suvojeet.suvmusic.core.model.PlaylistDisplayItem> = withContext(Dispatchers.IO) {
         val playlists = mutableListOf<com.suvojeet.suvmusic.core.model.PlaylistDisplayItem>()
-        
+
+        if (isRateLimited()) {
+            android.util.Log.w("RemoteAudio", "getFeaturedPlaylists SKIP backoff active")
+            return@withContext playlists
+        }
+
         try {
             // Fetch top charts/featured playlists
             val playlistsUrl = "$BASE_URL?${RemoteConstants.PARAM_CALL}${RemoteConstants.EP_CHARTS}&_format=json&n=20"
@@ -988,9 +1067,9 @@ class RemoteAudioRepository @Inject constructor(
             }
             
         } catch (e: Exception) {
-            e.printStackTrace()
+            android.util.Log.e("RemoteAudio", "getFeaturedPlaylists failed: ${e.javaClass.simpleName}: ${e.message}")
         }
-        
+
         playlists
     }
     
@@ -1006,11 +1085,16 @@ class RemoteAudioRepository @Inject constructor(
             .addHeader("Accept-Language", "en-US,en;q=0.9")
             .build()
 
-        return okHttpClient.newCall(request).execute().use { response ->
+        return boundedHttpClient.newCall(request).execute().use { response ->
             val body = response.body.string()
             if (!response.isSuccessful) {
+                // Legacy endpoints go through this raw path (not Retrofit), so a 429 here
+                // never reached the typed is429() check — arm the shared backoff directly
+                // so these callers stop hammering a rate-limited backend too.
+                if (response.code == 429) noteRateLimited()
                 android.util.Log.e("RemoteAudio", "HTTP ${response.code} for ${request.url.host}${request.url.encodedPath} (body ${body.length} chars)")
             } else {
+                noteSuccess()
                 android.util.Log.d("RemoteAudio", "HTTP ${response.code} ${request.url.host} — ${body.length} chars")
             }
             body

--- a/app/src/main/java/com/suvojeet/suvmusic/data/repository/youtube/streaming/InnerTubeClient.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/data/repository/youtube/streaming/InnerTubeClient.kt
@@ -29,8 +29,14 @@ import javax.inject.Singleton
  */
 @Singleton
 class InnerTubeClient @Inject constructor(
-    private val okHttpClient: OkHttpClient
+    okHttpClient: OkHttpClient
 ) {
+    // Per-call timeout so a single slow client identity can't hang the whole
+    // resolve. Clients are tried sequentially (IOS → ANDROID_VR → TV); without a
+    // cap, three stalled calls at the default ~30s each could block playback ~90s.
+    private val httpClient: OkHttpClient = okHttpClient.newBuilder()
+        .callTimeout(12, java.util.concurrent.TimeUnit.SECONDS)
+        .build()
     private data class ClientProfile(
         val clientName: String,
         val clientVersion: String,
@@ -100,7 +106,7 @@ class InnerTubeClient @Inject constructor(
             .post(payload.toRequestBody(jsonMedia))
             .build()
 
-        okHttpClient.newCall(request).execute().use { response ->
+        httpClient.newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
                 android.util.Log.w("InnerTube", "${client.clientName} HTTP ${response.code} for $videoId")
                 return null

--- a/app/src/main/java/com/suvojeet/suvmusic/data/repository/youtube/streaming/YouTubeStreamingService.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/data/repository/youtube/streaming/YouTubeStreamingService.kt
@@ -35,10 +35,27 @@ class YouTubeStreamingService @Inject constructor(
             ?: throw IllegalStateException("YouTube service not found")
     }
 
-    // Cache for stream URLs to avoid re-fetching (max 50 entries, 3 hours expiry)
+    // Cache for stream URLs to avoid re-fetching (max 50 entries).
+    // Backstop TTL only — the real gate is the URL's own `expire` param (see
+    // cachedUrlStillValid). googlevideo links are signed and die well before any
+    // fixed TTL, so a long TTL was serving dead URLs that failed with 403 mid-song.
     private data class CachedStream(val url: String, val extension: String, val timestamp: Long)
     private val streamCache = LruCache<String, CachedStream>(50)
-    private val CACHE_EXPIRY_MS = 3 * 60 * 60 * 1000L // 3 hours
+    private val CACHE_EXPIRY_MS = 60 * 60 * 1000L // 1 hour backstop
+
+    /**
+     * A cached stream URL is valid only if it's within the backstop TTL AND the
+     * signed URL hasn't reached (or is about to reach) its own expiry. googlevideo
+     * URLs carry `expire=<epochSeconds>`; we refresh 5 minutes early so playback
+     * never starts on a URL that dies seconds later with a 403.
+     */
+    private fun cachedUrlStillValid(cached: CachedStream): Boolean {
+        val now = System.currentTimeMillis()
+        if (now - cached.timestamp >= CACHE_EXPIRY_MS) return false
+        val expireSeconds = Regex("[?&]expire=(\\d+)").find(cached.url)?.groupValues?.getOrNull(1)?.toLongOrNull()
+        if (expireSeconds != null && now >= expireSeconds * 1000L - 5 * 60_000L) return false
+        return true
+    }
 
     // In-flight request dedup: if two callers ask for the same videoId concurrently,
     // they share one network fetch instead of racing duplicate requests.
@@ -111,11 +128,12 @@ class YouTubeStreamingService @Inject constructor(
         if (!forceLow) {
             streamCache.get(cacheKey)?.let { cached ->
                 val ageMs = System.currentTimeMillis() - cached.timestamp
-                if (ageMs < CACHE_EXPIRY_MS) {
+                if (cachedUrlStillValid(cached)) {
                     android.util.Log.i("YouTubeStreaming", "CACHE_HIT audio $videoId (age=${ageMs}ms)")
                     return@withContext cached.url
                 }
-                android.util.Log.i("YouTubeStreaming", "CACHE_STALE audio $videoId (age=${ageMs}ms > ${CACHE_EXPIRY_MS}ms)")
+                android.util.Log.i("YouTubeStreaming", "CACHE_STALE audio $videoId (age=${ageMs}ms, expired/expiring) — evicting")
+                streamCache.remove(cacheKey)
             } ?: android.util.Log.i("YouTubeStreaming", "CACHE_MISS audio $videoId")
         } else {
             android.util.Log.i("YouTubeStreaming", "CACHE_BYPASS audio $videoId (forceLow=true)")
@@ -308,12 +326,16 @@ class YouTubeStreamingService @Inject constructor(
             val cachedVideo = streamCache.get(videoCacheKey)
             val cachedAudio = streamCache.get(audioCacheKey)
 
-            if (cachedVideo != null && System.currentTimeMillis() - cachedVideo.timestamp < CACHE_EXPIRY_MS) {
+            if (cachedVideo != null && cachedUrlStillValid(cachedVideo) && (cachedAudio == null || cachedUrlStillValid(cachedAudio))) {
                 android.util.Log.d("YouTubeStreaming", "CACHE_HIT video $videoId/$targetQuality (age=${System.currentTimeMillis() - cachedVideo.timestamp}ms)")
                 return@withContext VideoStreamResult(
                     videoUrl = cachedVideo.url,
                     audioUrl = cachedAudio?.url
                 )
+            }
+            if (cachedVideo != null) {
+                streamCache.remove(videoCacheKey)
+                streamCache.remove(audioCacheKey)
             }
             android.util.Log.d("YouTubeStreaming", "CACHE_MISS video $videoId/$targetQuality")
         }
@@ -450,11 +472,12 @@ class YouTubeStreamingService @Inject constructor(
     suspend fun getStreamUrlForDownload(videoId: String): Pair<String, String>? = withContext(Dispatchers.IO) {
         val cacheKey = "audio_$videoId"
         streamCache.get(cacheKey)?.let { cached ->
-            if (System.currentTimeMillis() - cached.timestamp < CACHE_EXPIRY_MS) {
+            if (cachedUrlStillValid(cached)) {
                 return@withContext cached.url to cached.extension
             }
+            streamCache.remove(cacheKey)
         }
-        
+
         retryWithBackoff {
             val downloadQuality = sessionManager.getDownloadQuality()
             val streamUrl = "https://www.youtube.com/watch?v=$videoId"

--- a/app/src/main/java/com/suvojeet/suvmusic/player/MusicPlayer.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/player/MusicPlayer.kt
@@ -750,9 +750,13 @@ class MusicPlayer @Inject constructor(
                     // Wait for the observer to add more songs, then play the next one.
                     scope.launch {
                         val originalSize = queueSize
-                        // Retry up to 6 seconds (12 x 500ms) to allow autoplay to add songs
-                        repeat(12) {
-                            delay(500)
+                        // Tell the UI we're fetching more so radio doesn't look frozen
+                        // while the observer loads the next batch.
+                        _playerState.update { it.copy(isLoading = true, error = null) }
+                        // Retry up to ~15 seconds (20 x 750ms) — a slow network often
+                        // needs longer than the old 6s to deliver the next radio batch.
+                        repeat(20) {
+                            delay(750)
                             val updatedState = _playerState.value
                             if (updatedState.queue.size > originalSize) {
                                 val newIndex = originalSize
@@ -768,8 +772,12 @@ class MusicPlayer @Inject constructor(
                                 return@launch
                             }
                         }
-                        // Timeout: no new songs were added — playback stops
+                        // Timeout: no new songs were added — surface it instead of going
+                        // silent so the user knows radio stalled and can retry.
                         android.util.Log.w("MusicPlayer", "STATE_ENDED: autoplay timeout, no new songs loaded")
+                        _playerState.update {
+                            it.copy(isLoading = false, error = "Couldn't load more songs. Tap next to retry.")
+                        }
                     }
                 }
                 // RepeatMode.OFF at end of queue (no autoplay) — playback stops naturally (correct)
@@ -1191,10 +1199,19 @@ class MusicPlayer @Inject constructor(
                              }
                              resolvedVideoIds.remove(currentSong.id)
                         } else if (isExpiredUrl && currentSong.source == SongSource.YOUTUBE) {
-                             // Improvement (2): 403 Forbidden Search Fallback
-                             // Clear cached ID to force a fresh search resolution
+                             // 403/410 Forbidden — the signed stream URL died. Purge the
+                             // cached (dead) URL so re-resolution fetches a fresh one;
+                             // without this, getStreamUrl would just hand back the same
+                             // expired URL and we'd loop. Also clear the resolved-id map
+                             // so a stale video match can be re-searched.
+                             streamingService.clearCacheFor(currentSong.id)
                              resolvedVideoIds.remove(currentSong.id)
                              _playerState.update { it.copy(isLoading = true, error = "Stream expired, finding alternative...") }
+                        } else if (isExpiredUrl && currentSong.source == SongSource.REMOTE) {
+                             // Same problem on the RemoteAudio path: drop the cached URL/details
+                             // so the retry re-resolves instead of replaying the dead link.
+                             remoteAudioRepository.invalidate(currentSong.id)
+                             _playerState.update { it.copy(isLoading = true, error = "Stream expired, refreshing...") }
                         } else {
                              _playerState.update { it.copy(isLoading = true, error = null) }
                         }
@@ -2171,6 +2188,13 @@ class MusicPlayer @Inject constructor(
         preloadJob?.cancel()
         isPreloading = false
         lastPreloadAttemptTime = 0L
+        // Clear the cached preload result too. Cancelling the job alone left these set,
+        // so a preload that completed just as the user skipped could later be applied to
+        // the wrong song in onMediaItemTransition's fast-path.
+        preloadedNextSongId = null
+        preloadedStreamUrl = null
+        preloadedIsVideoMode = false
+        preloadedTimestamp = 0L
         val state = _playerState.value
         val queue = state.queue
         if (queue.isEmpty()) return
@@ -2291,6 +2315,16 @@ class MusicPlayer @Inject constructor(
         val queue = state.queue
         if (queue.isEmpty()) return
         val controller = mediaController ?: return
+
+        // Drop any preload aimed at the old "next" — after stepping back it no longer
+        // matches the upcoming item and could be applied to the wrong song.
+        preloadJob?.cancel()
+        isPreloading = false
+        lastPreloadAttemptTime = 0L
+        preloadedNextSongId = null
+        preloadedStreamUrl = null
+        preloadedIsVideoMode = false
+        preloadedTimestamp = 0L
 
         // Wait for the in-flight resolution to actually finish cancelling before
         // we trigger seekToPreviousMediaItem — otherwise the still-running

--- a/app/src/main/java/com/suvojeet/suvmusic/service/MusicPlayerService.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/service/MusicPlayerService.kt
@@ -1011,7 +1011,13 @@ class MusicPlayerService : MediaLibraryService() {
                             }
                         }
 
-                        val resolved = finalItems.mapIndexed { index, item ->
+                        // Bound the whole start-item resolution. resolveStreamUrlWithRetry
+                        // can take ~30s worst case; without an outer cap, Android Auto /
+                        // Bluetooth controllers sit unresponsive waiting on this future.
+                        // On timeout we return the placeholders and let onPlayerError /
+                        // onMediaItemTransition resolve lazily, so controls appear promptly.
+                        val resolved = (kotlinx.coroutines.withTimeoutOrNull(20_000L) {
+                          finalItems.mapIndexed { index, item ->
                             // Only resolve URI for the START item to keep latency low.
                             // The rest will be resolved lazily by onMediaItemTransition in the service.
                             if (index != finalStartIndex) return@mapIndexed item
@@ -1040,7 +1046,10 @@ class MusicPlayerService : MediaLibraryService() {
                             } else {
                                 item // Keep as placeholder if resolution fails, onPlayerError might handle it
                             }
-                        }.toMutableList()
+                          }.toMutableList()
+                        } ?: finalItems.toMutableList().also {
+                            android.util.Log.w("MusicPlayerService", "onSetMediaItems resolution timed out — returning placeholders for lazy resolution")
+                        })
 
                         if (resolved.isEmpty()) {
                             future.set(MediaSession.MediaItemsWithStartPosition(emptyList(), 0, 0L))

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/viewmodel/PlayerViewModel.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/viewmodel/PlayerViewModel.kt
@@ -387,15 +387,14 @@ class PlayerViewModel @Inject constructor(
                         // Notify recommendation engine of song change for adaptive recommendations
                         recommendationEngine.onSongPlayed(song)
                         
-                        // Reset sync state for new song
-                        if (song.id != lastSyncedVideoId) {
-                            currentSongPlayTime = 0
-                            // Allow re-sync if it's a new song ID. 
-                            // If it's the same song ID (repeat), we might not want to spam sync.
-                            // But usually repeat implies a new listen. 
-                            // For safety, let's reset lastSyncedVideoId if the song CHANGED.
-                             lastSyncedVideoId = null 
-                        }
+                        // Reset sync state on every distinct song start. This flow only
+                        // emits when currentSong actually changes (distinctUntilChanged),
+                        // so each emission is a genuine new listen session — including
+                        // replaying a song we just synced (A→B→A). The old guard kept
+                        // lastSyncedVideoId set when returning to a recently-synced song,
+                        // which silently dropped that replay's listen.
+                        currentSongPlayTime = 0
+                        lastSyncedVideoId = null
 
                         // Reset provider to AUTO on song change unless user specifically locked a provider?
                         // For now, let's keep it persistent or reset. Resetting is safer for "Best Match".


### PR DESCRIPTION
Streaming layer:
- YouTube stream cache is now expire-aware: honor the URL's own
  expire param (refresh 5 min early) instead of trusting a 3h TTL,
  and evict stale entries — stops 403s from cached-but-dead URLs.
- RemoteAudio getStreamUrl now retries transient failures and bails
  on genuinely-blank URLs (parity with the YouTube retry path).
- Bound all RemoteAudio in-memory caches (LRU) so long sessions
  don't leak; add invalidate(songId) to drop a dead URL on demand.
- Arm the 429 backoff from every caller: makeRequest now notes 429,
  and getPlaylist/getAlbum/searchArtists/getArtist/getFeaturedPlaylists
  skip while backing off — no more invisible throttle extension.
- Cap raw HTTP and InnerTube calls with explicit callTimeouts so a
  stalled endpoint can't hang resolve/prefetch for ~30-90s.

Player/engine:
- On a 403/410 mid-playback, purge the cached dead URL (YouTube and
  RemoteAudio) before re-resolving so recovery can actually succeed.
- Clear cached preload state on skip next/previous so a late preload
  can't be applied to the wrong song.
- End-of-queue autoplay now shows a loading state, waits longer, and
  surfaces an error instead of silently stopping.

Service/UI:
- Bound onSetMediaItems start-item resolution (20s) so Android Auto /
  Bluetooth controllers don't sit unresponsive.
- Reset history-sync state on every distinct song start so replaying
  a just-synced song still records the listen.

https://claude.ai/code/session_0124ijGmARoutLfkdC42PvrK