### PR TITLE
Address remaining audit items across playback, data, UI, infra, build

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -31,5 +31,28 @@ Senior Android Engineer with a track record of delivering mission-critical mobil
 - **LinkedIn**: [Suvojeet Sengupta](https://www.linkedin.com/in/suvojeet-sengupta/)
 - **Email**: [suvojeet@suvojeetsengupta.in](mailto:suvojeet@suvojeetsengupta.in)
 
+## Build system: KMP plugin migration status
+
+We are migrating modules to the AGP 9 KMP-aware Android library plugin
+(`com.android.kotlin.multiplatform.library`, which replaces `com.android.library` +
+`androidTarget()`). The **legacy** pattern is removed under AGP 10, so the remaining
+modules below must be migrated before bumping AGP to 10.
+
+| Module | Plugin | Status |
+|---|---|---|
+| `:composeApp` | AGP 9 KMP-aware | ✅ migrated |
+| `:core:model` | AGP 9 KMP-aware | ✅ migrated |
+| `:app` | legacy `com.android.application` | n/a (application module) |
+| `:core:data` | legacy | ⏳ pending |
+| `:core:domain` | legacy | ⏳ pending |
+| `:extractor` | legacy | ⏳ pending |
+| `:media-source` | legacy | ⏳ pending |
+| `:scrobbler` | legacy | ⏳ pending |
+| `:updater` | legacy | ⏳ pending |
+| `:lyric-lrclib` / `:lyric-kugou` / `:lyric-simpmusic` | legacy | ⏳ pending |
+
+> When migrating a module, mirror `:core:model/build.gradle.kts`. Update this table in
+> the same PR. Do not bump AGP to 10 until every ⏳ row is ✅.
+
 ---
 *Generated for SEO and Search Visibility Optimization.*

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -50,6 +50,18 @@
 -keepclassmembers,allowobfuscation class com.suvojeet.suvmusic.cache.** {
     <fields>;
 }
+# AI effect/prompt models (ai/AIModels.kt: AudioEffectState, AIPromptHistory,
+# SongAISettings) are Gson-serialized by reflection. Same failure mode as the cache
+# wrappers above: under R8 full mode their renamed fields stop matching the JSON keys
+# and Gson silently deserializes to defaults. Keep their fields.
+-keepclassmembers,allowobfuscation class com.suvojeet.suvmusic.ai.** {
+    <fields>;
+}
+
+# Audit aid (see audit B2): emit the fully-merged R8 configuration so the team can
+# inspect exactly what is kept/renamed on a release build and catch the next missing
+# reflection -keep before it ships.
+-printconfiguration build/r8-merged-configuration.txt
 
 # Strip only verbose / debug Log calls in release. Info / warn / error
 # survive so diagnostic logs (stream resolution traces, NewPipe failures,

--- a/app/src/main/java/com/suvojeet/suvmusic/data/SessionManager.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/data/SessionManager.kt
@@ -322,17 +322,21 @@ class SessionManager @Inject constructor(
                         // Float is used for alpha/spacing.
                         
                         val doubleVal = value.toDouble()
-                        
+
                         // Heuristic: if it's a whole number, it might be Int or Long
                         if (doubleVal == doubleVal.toLong().toDouble()) {
-                             // Try common Long keys
-                             if (keyName.contains("timestamp") || keyName.contains("time") || 
+                             val longVal = value.toLong()
+                             // Use Long for known time-ish keys OR any value that won't fit
+                             // in an Int — the latter guards against a timestamp/position
+                             // silently overflowing when forced through toInt().
+                             if (keyName.contains("timestamp") || keyName.contains("time") ||
                                  keyName.contains("position") || keyName.contains("at") ||
-                                 keyName.contains("limit")) {
-                                 prefs[longPreferencesKey(keyName)] = value.toLong()
+                                 keyName.contains("limit") ||
+                                 longVal > Int.MAX_VALUE || longVal < Int.MIN_VALUE) {
+                                 prefs[longPreferencesKey(keyName)] = longVal
                              } else {
                                  // Default to Int for small whole numbers
-                                 prefs[intPreferencesKey(keyName)] = value.toInt()
+                                 prefs[intPreferencesKey(keyName)] = longVal.toInt()
                              }
                         } else {
                              // Float for fractional values

--- a/app/src/main/java/com/suvojeet/suvmusic/data/repository/DownloadRepository.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/data/repository/DownloadRepository.kt
@@ -137,11 +137,14 @@ class DownloadRepository @Inject constructor(
         }
     }
 
-    private fun scanFolderRecursive(folder: File, currentSongs: MutableList<Song>, collectionName: String? = null): Boolean {
+    private suspend fun scanFolderRecursive(folder: File, currentSongs: MutableList<Song>, collectionName: String? = null): Boolean {
         var hasNew = false
         val files = folder.listFiles() ?: return false
-        
+
         for (file in files) {
+            // Cooperative cancellation: a deep tree on the IO pool would otherwise
+            // run to completion even after the caller's scope is cancelled.
+            currentCoroutineContext().ensureActive()
             if (file.isDirectory) {
                 // Use subfolder name as collection name
                 if (scanFolderRecursive(file, currentSongs, file.name)) hasNew = true

--- a/app/src/main/java/com/suvojeet/suvmusic/data/repository/RemoteAudioRepository.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/data/repository/RemoteAudioRepository.kt
@@ -132,6 +132,13 @@ class RemoteAudioRepository @Inject constructor(
      * Typed variant of [search]: returns [AppResult.Success] (possibly with an empty list
      * when the backend genuinely had nothing) or [AppResult.Failure] with a classified
      * [com.suvojeet.suvmusic.core.model.AppError]. Failures are also reported to telemetry.
+     *
+     * POLICY: this backend rate-limits (429) aggressively. It must only be called from the
+     * Search tab, song-detail resolution, and the hybrid HQ playback path — NEVER from home
+     * / recommendation section generation (which fires one search per row). The recommendation
+     * engine routes home content through YouTube only; do not add a RemoteAudio call there.
+     * Every call is logged below, so a stray home-path call shows up as a burst of RemoteAudio
+     * searches in logcat.
      */
     suspend fun searchResult(query: String): AppResult<List<Song>> = withContext(Dispatchers.IO) {
         val cacheKey = query.trim().lowercase()

--- a/app/src/main/java/com/suvojeet/suvmusic/data/repository/youtube/streaming/potoken/PoTokenWebView.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/data/repository/youtube/streaming/potoken/PoTokenWebView.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.withContext
 import okhttp3.Headers.Companion.toHeaders
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
+import org.json.JSONObject
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Collections
@@ -210,7 +211,7 @@ class PoTokenWebView private constructor(
                 // NOTE: obtainPoToken is now async, so we use .then()
                 webView.evaluateJavascript(
                     """try {
-                        identifier = "$identifier"
+                        identifier = ${JSONObject.quote(identifier)}
                         u8Identifier = ${stringToU8(identifier)}
                         obtainPoToken(u8Identifier).then(function(poTokenU8) {
                             poTokenU8String = poTokenU8.join(",")

--- a/app/src/main/java/com/suvojeet/suvmusic/discord/DiscordManager.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/discord/DiscordManager.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -24,7 +25,9 @@ class DiscordManager @Inject constructor(
     private var useDetails: Boolean = false
     private var isIncognitoMode: Boolean = false
     
-    private val scope = CoroutineScope(Dispatchers.IO)
+    // SupervisorJob so a single failing collector (e.g. the incognito-mode flow)
+    // doesn't cancel the whole scope and silently kill future Discord updates.
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var initializationJob: Job? = null
     
     private val _connectionStatus = MutableStateFlow("Disconnected")

--- a/app/src/main/java/com/suvojeet/suvmusic/discord/DiscordRPC.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/discord/DiscordRPC.kt
@@ -285,6 +285,14 @@ class DiscordRPC(
         } catch (e: Exception) {
             AppLog.e(tag, "Error closing gateway", e)
         }
+        // Release the ktor HttpClient too — close() means this instance is done
+        // (DiscordManager.disconnect nulls it and connect() builds a fresh one), so
+        // its engine/threads would otherwise leak for every enable/disable cycle.
+        try {
+            client.close()
+        } catch (e: Exception) {
+            AppLog.e(tag, "Error closing HttpClient", e)
+        }
     }
 
     fun updateActivity(

--- a/app/src/main/java/com/suvojeet/suvmusic/player/MusicPlayer.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/player/MusicPlayer.kt
@@ -108,6 +108,7 @@ class MusicPlayer @Inject constructor(
     
     // Audio Manager for device detection
     private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    private val powerManager = context.getSystemService(Context.POWER_SERVICE) as android.os.PowerManager
     
     // Preloading state for gapless playback
     private var preloadedNextSongId: String? = null
@@ -591,17 +592,28 @@ class MusicPlayer @Inject constructor(
         val capturedId = manualSelectedDeviceId
         val capturedName = manualSelectedDeviceName
         if (!hasSelection && isInGracePeriod && capturedId != null && capturedName != null) {
-            val placeholderDevice = OutputDevice(
-                id = capturedId,
-                name = capturedName,
-                type = DeviceType.BLUETOOTH, // Assume Bluetooth for grace period issues
-                isSelected = true
-            )
-            // Add at correct position or replace if same name exists
-            val newList = devicesWithSelection.toMutableList()
-            newList.add(placeholderDevice)
-            devicesWithSelection = newList
-            hasSelection = true
+            // A reconnecting Bluetooth device often comes back under a NEW device id
+            // (fresh ACL session). If a real device with the same name is now present,
+            // adopt its new id and select it — otherwise the grace placeholder pins the
+            // stale id and blocks recognising the reconnected device for up to 10s.
+            val reconnected = devicesWithSelection.firstOrNull { it.name == capturedName }
+            if (reconnected != null) {
+                manualSelectedDeviceId = reconnected.id
+                devicesWithSelection = devicesWithSelection.map { it.copy(isSelected = it.id == reconnected.id) }
+                hasSelection = true
+            } else {
+                val placeholderDevice = OutputDevice(
+                    id = capturedId,
+                    name = capturedName,
+                    type = DeviceType.BLUETOOTH, // Assume Bluetooth for grace period issues
+                    isSelected = true
+                )
+                // Add at correct position or replace if same name exists
+                val newList = devicesWithSelection.toMutableList()
+                newList.add(placeholderDevice)
+                devicesWithSelection = newList
+                hasSelection = true
+            }
         }
 
         if (!hasSelection && !isInGracePeriod) {
@@ -1339,7 +1351,14 @@ class MusicPlayer @Inject constructor(
             // back to the /songs/{id} detail endpoint if it's somehow missing (that
             // endpoint rate-limits hardest, so we keep it off the hot play path).
             val url = match?.let { remoteStreamUrlFor(it) }
-            hybridRemoteIds.put(song.id, url ?: "")
+            // Only cache a genuine result: a positive URL, or a real "no match". If the
+            // backend was merely busy (rate-limited / timeout / no network) we must NOT
+            // negatively-cache the miss — otherwise the song stays pinned to YouTube for
+            // the rest of the session even after the HQ service recovers. The shared 429
+            // backoff gate keeps the retry from hammering the backend.
+            if (url != null || !busy) {
+                hybridRemoteIds.put(song.id, url ?: "")
+            }
             hqFallbackReason.put(
                 song.id,
                 when {
@@ -1724,9 +1743,13 @@ class MusicPlayer @Inject constructor(
             kotlinx.coroutines.flow.flow {
                 while (true) {
                     emit(Unit)
-                    // Adaptive delay: faster when playing for smooth seekbar, slower when paused/buffering
+                    // Adaptive delay: faster when playing for smooth seekbar, slower when
+                    // paused/buffering. When the screen is off, nothing renders the
+                    // fine-grained position, so drop to the slow cadence to save battery
+                    // on metered/screen-off playback.
                     val isPlaying = mediaController?.isPlaying == true
-                    kotlinx.coroutines.delay(if (isPlaying) 400L else 1000L)
+                    val screenOn = powerManager.isInteractive
+                    kotlinx.coroutines.delay(if (isPlaying && screenOn) 400L else 1000L)
                 }
             }.collect {
                 mediaController?.let { controller ->

--- a/app/src/main/java/com/suvojeet/suvmusic/recommendation/RecommendationEngine.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/recommendation/RecommendationEngine.kt
@@ -167,14 +167,30 @@ class RecommendationEngine @Inject constructor(
      * Source-aware song search used by all discovery/section generators so the
      * home screen stays consistent with the active source (RemoteAudio vs YouTube).
      */
-    private suspend fun searchSongs(query: String): List<Song> = try {
+    // Short-lived query cache so multiple discovery generators (genre rows, artist
+    // mixes, context sections) that search the same query within one refresh share a
+    // single YouTube round-trip instead of each firing their own — the N+1 the home
+    // rows otherwise cause.
+    private val searchQueryCache = ConcurrentHashMap<String, Pair<Long, List<Song>>>()
+    private val searchCacheTtlMs = 5 * 60 * 1000L
+
+    private suspend fun searchSongs(query: String): List<Song> {
         // Home/recommendation content ALWAYS comes from YouTube. The RemoteAudio (HQ)
         // backend is reserved for playback stream resolution + the explicit Search tab;
         // the home screen must never call it, since firing one search per genre row /
         // artist mix / context section is exactly what triggers its 429 rate-limiting.
-        youTubeRepository.search(query, YouTubeRepository.FILTER_SONGS)
-    } catch (e: Exception) {
-        emptyList()
+        val key = query.trim().lowercase()
+        val now = System.currentTimeMillis()
+        searchQueryCache[key]?.let { (ts, songs) ->
+            if (now - ts < searchCacheTtlMs) return songs
+        }
+        return try {
+            val result = youTubeRepository.search(query, YouTubeRepository.FILTER_SONGS)
+            if (result.isNotEmpty()) searchQueryCache[key] = now to result
+            result
+        } catch (e: Exception) {
+            emptyList()
+        }
     }
 
     // ============================================================================================
@@ -206,10 +222,9 @@ class RecommendationEngine @Inject constructor(
                 apiSemaphore.withPermit {
                     try {
                         // Always YouTube — home content never touches the RemoteAudio backend.
-                        val songs = youTubeRepository.search(
-                            "$genreName music mix",
-                            YouTubeRepository.FILTER_SONGS
-                        )
+                        // Routed through searchSongs so repeated genre queries within a
+                        // refresh hit the short-TTL cache instead of re-querying YouTube.
+                        val songs = searchSongs("$genreName music mix")
                         val scored = scoreAndRank(songs, profile)
                         val unique = deduplicate(scored, seenIds, seenFingerprints).take(12)
                         if (unique.isNotEmpty()) {

--- a/app/src/main/java/com/suvojeet/suvmusic/service/MusicPlayerService.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/service/MusicPlayerService.kt
@@ -428,6 +428,10 @@ class MusicPlayerService : MediaLibraryService() {
                         startSponsorBlockMonitoring()
                     } else {
                         sponsorBlockJob?.cancel()
+                        // Re-arm the audio-sink kickstart on pause. On the affected
+                        // devices a READY->PAUSED->READY cycle without a BUFFERING state
+                        // would otherwise skip the unmute nudge and resume silently.
+                        audioSinkKickstartDone = false
                     }
                 }
 

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/components/WaveformSeeker.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/components/WaveformSeeker.kt
@@ -224,7 +224,11 @@ fun WaveformSeeker(
                             dragX = offset.x
                         },
                         onDragEnd = {
-                            onSeek(currentProgress)
+                            // Don't deliver a stale seek if the player is no longer in a
+                            // valid state. A dismissed sheet / cleared queue drops duration
+                            // to 0, so an in-flight drag would otherwise seek an invalid
+                            // position on teardown.
+                            if (duration > 0) onSeek(currentProgress)
                             isDragging = false
                         },
                         onHorizontalDrag = { change, _ ->

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/components/player/miniplayer/LiquidGlassMiniPlayer.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/components/player/miniplayer/LiquidGlassMiniPlayer.kt
@@ -98,14 +98,18 @@ fun LiquidGlassMiniPlayer(
     ) {
         val interactionSource = remember { MutableInteractionSource() }
         val isPressed by interactionSource.collectIsPressedAsState()
+        // One shared spec for both press animations so scale and background settle in
+        // lockstep — using different springs made rapid taps flicker as one finished
+        // before the other.
+        val pressSpec = spring<Float>(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMedium)
         val scale by animateFloatAsState(
             targetValue = if (isPressed) 0.82f else 1f,
-            animationSpec = spring(Spring.DampingRatioLowBouncy, Spring.StiffnessMedium),
+            animationSpec = pressSpec,
             label = "glassBtnScale"
         )
         val bgAlpha by animateFloatAsState(
             targetValue = if (isPressed) 0.18f else 0f,
-            animationSpec = spring(Spring.DampingRatioNoBouncy, Spring.StiffnessMedium),
+            animationSpec = pressSpec,
             label = "glassBtnBg"
         )
         Box(

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/screens/HomeScreen.kt
@@ -38,6 +38,9 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Radio
 import androidx.compose.material.icons.filled.Refresh
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.material.icons.filled.WbSunny
@@ -132,20 +135,24 @@ fun HomeScreen(
     
     val lazyListState = rememberLazyListState()
 
-    // Handle Events
-    LaunchedEffect(Unit) {
-        viewModel.events.collect { event ->
-            when (event) {
-                is HomeEvent.ShowAddToPlaylistSheet -> {
-                    playlistViewModel.showAddToPlaylistSheet(event.song)
-                }
-                is HomeEvent.ScrollToTop -> {
-                    if (uiState.homeSections.isNotEmpty() || uiState.recommendations.isNotEmpty()) {
-                        lazyListState.animateScrollToItem(0)
+    // Handle Events — collected lifecycle-aware so UI actions (sheets, scroll)
+    // aren't dispatched against a paused/destroyed screen.
+    val homeLifecycleOwner = LocalLifecycleOwner.current
+    LaunchedEffect(homeLifecycleOwner) {
+        homeLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.events.collect { event ->
+                when (event) {
+                    is HomeEvent.ShowAddToPlaylistSheet -> {
+                        playlistViewModel.showAddToPlaylistSheet(event.song)
                     }
-                }
-                is HomeEvent.Refresh -> {
-                   // Refresh is already triggered in ViewModel, which sets isRefreshing = true
+                    is HomeEvent.ScrollToTop -> {
+                        if (uiState.homeSections.isNotEmpty() || uiState.recommendations.isNotEmpty()) {
+                            lazyListState.animateScrollToItem(0)
+                        }
+                    }
+                    is HomeEvent.Refresh -> {
+                       // Refresh is already triggered in ViewModel, which sets isRefreshing = true
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerArtwork.kt
+++ b/app/src/main/java/com/suvojeet/suvmusic/ui/screens/player/components/PlayerArtwork.kt
@@ -14,6 +14,8 @@ import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.LinearEasing
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -155,13 +157,19 @@ fun AlbumArtwork(
     
     LaunchedEffect(isPlaying, currentShape, isRotatingEnabled) {
         if (isPlaying && currentShape == ArtworkShape.VINYL && isRotatingEnabled) {
-            // Continuously animate. 
-            // We use a simple loop to keep it rotating.
-            while (true) {
-                rotationAnimatable.animateTo(
-                    targetValue = rotationAnimatable.value + 360f,
-                    animationSpec = tween(8000, easing = LinearEasing)
-                )
+            try {
+                // Continuously animate.
+                // We use a simple loop to keep it rotating.
+                while (true) {
+                    rotationAnimatable.animateTo(
+                        targetValue = rotationAnimatable.value + 360f,
+                        animationSpec = tween(8000, easing = LinearEasing)
+                    )
+                }
+            } finally {
+                // Settle on cancellation (key change / leaving the screen) so the
+                // Animatable isn't left in a half-finished running state.
+                withContext(NonCancellable) { rotationAnimatable.snapTo(rotationAnimatable.value) }
             }
         } else {
             rotationAnimatable.stop()

--- a/scrobbler/src/main/java/com/suvojeet/suvmusic/lastfm/LastFmClient.kt
+++ b/scrobbler/src/main/java/com/suvojeet/suvmusic/lastfm/LastFmClient.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.security.MessageDigest
 import javax.inject.Inject
+import javax.inject.Singleton
 
 interface LastFmConfig {
     val apiKey: String
@@ -22,6 +23,10 @@ interface LastFmConfig {
     val userAgent: String get() = "SuvMusic (https://github.com/suvojeet-sengupta/SuvMusic)"
 }
 
+// Singleton so the owned ktor HttpClient (CIO) below exists exactly once for the
+// whole app instead of one engine per injection site — it lives for the process
+// lifetime and is never explicitly closed, so it must not be allowed to multiply.
+@Singleton
 class LastFmClient @Inject constructor(
     private val config: LastFmConfig
 ) {


### PR DESCRIPTION
Completes the deferred findings from BUGS_AND_IMPROVEMENTS_AUDIT.md.

Playback:
- Don't negatively-cache HQ "busy" misses, so songs re-resolve to HQ after the backend recovers instead of staying on YouTube for the session (P18)
- Lengthen the position tick when the screen is off (P19)
- Re-arm the audio-sink kickstart on pause so resume isn't silent (P12)
- Adopt a reconnecting BT device's new id during the selection grace window (P17)

Data:
- Use Long for restored whole-number settings too large for Int (D4)
- Document the RemoteAudio "no home-path calls" policy at the call site (D6)
- Short-TTL query cache for discovery searches; route genre rows through it (D7)
- Make the recursive download scan suspend + cooperatively cancellable (D11)

UI:
- Gate WaveformSeeker drag-end seek on a valid duration (U6)
- Settle the vinyl rotation Animatable on cancellation (U11)
- Share one spring spec for the glass button press animation (U15)
- Lifecycle-aware event collection in HomeScreen (U17)

Infra:
- JSON-encode the PoToken WebView identifier (I4)
- Close the Discord ktor HttpClient on disconnect; supervise the manager scope (I9)
- Make LastFmClient a singleton so its HttpClient can't multiply (I14)

Build:
- Keep ai/AIModels Gson fields under R8 full mode + emit merged R8 config (B2)
- Track the KMP plugin migration status in DEVELOPER.md (B8)